### PR TITLE
Define microbatching semantics for ingress pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,85 @@
 # v2-experiment
-A sandboxed experiment in analytics-enabled digital-twins based on messaging patterns with NATS.
+
+A digital twin framework for event-driven systems in Go.
+
+**Input at runtime**: domain-specific deltas (partial updates describing
+observed changes in the physical system). **Input at compile time**: a formal
+domain model defined as Go structs. **Output**: partitioned Parquet files
+(bronze snapshots, silver baselines) and a stream of per-entity snapshot updates
+over NATS.
+
+## Why
+
+This repository is an experimental playground: a space to demonstrate
+feasibility and evolve the concepts behind analytics-enabled digital twins
+before placing them in proper repositories under
+[go-digitaltwin](https://github.com/go-digitaltwin).
+
+## Core Concepts
+
+- **Domain model**: A compile-time schema of entity types. Each entity type has
+  a primary key, zero or more properties, and optional relationships to other
+  entity types. Defined as Go structs.
+- **Delta model**: Partial updates expressed per field as _assert_ (we know this
+  value), _retract_ (previously asserted value is no longer valid), or _ignore_
+  (field is unaffected). See [docs/design.md](docs/design.md) for motivation.
+- **Medallion storage**: A two-tier Parquet layout. Bronze stores both raw
+  deltas and full-state snapshots within windows. Silver stores the latest state
+  of every known entity.
+- **NATS messaging**: Services communicate through NATS subjects, enabling
+  independent scaling and loose coupling.
+
+## Architecture
+
+The event source is external (the user's system). The framework boundary starts
+at deltas-in and ends at Parquet-out and snapshots-out.
+
+```mermaid
+flowchart LR
+    subgraph external["Event Source (user's system)"]
+        Instrument["Instrument"]
+    end
+
+    subgraph framework["Digital Twin Framework"]
+        direction TB
+        Entities["Entities Service"]
+        Batcher["Bronze Batcher"]
+    end
+
+    subgraph storage["Storage"]
+        Bronze["Bronze Parquet"]
+        Silver["Silver Parquet"]
+    end
+
+    subgraph consumers["Consumers"]
+        Deltas["Raw Deltas<br/>(NATS)"]
+        Snapshots["Live Snapshots<br/>(NATS)"]
+        Analytics["Analytics<br/>(DuckDB)"]
+    end
+
+    Instrument -- "deltas (NATS)" --> Entities
+    Instrument -. "raw deltas (NATS)" .-> Deltas
+    Entities -- "snapshots (NATS)" --> Batcher
+    Entities -- "snapshots (NATS)" --> Snapshots
+    Batcher -- "writes" --> Bronze
+    Bronze -. "triggers" .-> Silver
+    Bronze --> Analytics
+    Silver --> Analytics
+    Silver -. "recovery" .-> Entities
+```
+
+## Repository Layout
+
+```
+v2-experiment/
+  docs/           Design documents, ADRs, and reference material
+  sample/         Concrete domain model examples (future)
+```
+
+## Status
+
+Experimental. Expect breaking changes.
+
+## License
+
+[MIT](LICENSE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Documentation
+
+| Document                                                                     | Description                                     |
+| ---------------------------------------------------------------------------- | ----------------------------------------------- |
+| [design.md](design.md)                                                       | Framework design: vision, architecture, storage |
+| [adr/](adr/)                                                                 | Architectural decision records (MADR 4.0.0)     |
+| [reference/whiteboard-architecture.md](reference/whiteboard-architecture.md) | Original architecture whiteboard sketch         |

--- a/docs/adr/001-use-architectural-decision-records.md
+++ b/docs/adr/001-use-architectural-decision-records.md
@@ -1,0 +1,43 @@
+---
+status: accepted
+date: 2026-03-03
+---
+
+# Use Architectural Decision Records
+
+## Context and Problem Statement
+
+Design decisions in this project will accumulate over time. Without a structured
+record, the rationale behind past decisions becomes tribal knowledge that is
+lost when context shifts or contributors change.
+
+## Decision Drivers
+
+- Decisions should be discoverable alongside the code they affect.
+- The format should be lightweight enough that writing an ADR is not a burden.
+- Both human readers and LLMs working with the codebase benefit from a
+  consistent, structured format.
+
+## Considered Options
+
+- **Architectural Decision Records in the repository** — structured Markdown
+  files committed with the code.
+- **Wiki or external documentation** — decisions recorded outside the
+  repository.
+- **No formal record** — rely on commit messages and pull request descriptions.
+
+## Decision Outcome
+
+Chosen option: "Architectural Decision Records in the repository." Keeping ADRs
+in the repo ensures they are versioned with the code, reviewable in pull
+requests, and available offline.
+
+### Consequences
+
+- Every significant architectural decision gets a dedicated file in `docs/adr/`.
+- ADRs are immutable once accepted; superseding decisions reference the
+  original.
+
+## More Information
+
+- [ADR GitHub organization](https://adr.github.io/)

--- a/docs/adr/002-madr-format-with-frontmatter.md
+++ b/docs/adr/002-madr-format-with-frontmatter.md
@@ -1,0 +1,49 @@
+---
+status: accepted
+date: 2026-03-03
+---
+
+# Use MADR 4.0.0 with YAML Frontmatter
+
+## Context and Problem Statement
+
+Having decided to use ADRs
+([ADR-001](001-use-architectural-decision-records.md)), we need a consistent
+template. The template should be structured enough to guide authors yet flexible
+enough to omit sections that add no value for straightforward decisions.
+
+## Decision Drivers
+
+- A widely adopted format reduces the learning curve for contributors.
+- YAML frontmatter enables tooling (status dashboards, search, LLM parsing)
+  without custom parsers.
+- Optional sections keep simple ADRs concise.
+
+## Considered Options
+
+- **MADR 4.0.0 with YAML frontmatter** — the latest version of the Markdown Any
+  Decision Records template, extended with machine-readable metadata.
+- **MADR 4.0.0 without frontmatter** — same template, status encoded only in the
+  heading or body text.
+- **Nygard format** — the original short-form ADR template.
+
+## Decision Outcome
+
+Chosen option: "MADR 4.0.0 with YAML frontmatter." The structured frontmatter
+(`status`, `date`) makes ADRs queryable by tools while the MADR body provides a
+familiar, well-documented structure.
+
+Optional MADR sections (Pros and Cons per option, Confirmation, More
+Information) are included only when they add value.
+
+### Consequences
+
+- Every ADR begins with a YAML frontmatter block containing at least `status`
+  and `date`.
+- The body follows the MADR 4.0.0 template.
+
+## More Information
+
+- [MADR 4.0.0][madr]
+
+[madr]: https://adr.github.io/madr/

--- a/docs/adr/003-compile-time-domain-model.md
+++ b/docs/adr/003-compile-time-domain-model.md
@@ -1,0 +1,54 @@
+---
+status: accepted
+date: 2026-03-03
+---
+
+# Define Domain Models at Compile Time
+
+## Context and Problem Statement
+
+The digital twin framework needs to know the shape of each entity type (primary
+keys, properties, relationships) in order to apply deltas, emit snapshots, and
+write Parquet files. This schema can be provided at compile time (Go structs) or
+at runtime (configuration files, reflection).
+
+## Decision Drivers
+
+- Type safety: delta builders and snapshot accessors should be checked by the
+  compiler.
+- Performance: avoiding reflection on the hot path (delta application) matters
+  for throughput.
+- Developer experience: Go structs are familiar, IDE-navigable, and
+  self-documenting.
+- Extensibility: runtime-defined schemas would allow dynamic onboarding of new
+  entity types without recompilation.
+
+## Considered Options
+
+- **Compile-time Go structs** — entity types defined as exported Go types; code
+  generation produces delta builders and Parquet serializers.
+- **Runtime schema definition** — entity types loaded from YAML/JSON
+  configuration at startup; all operations use reflection or generic maps.
+- **Hybrid** — compile-time structs as the primary path, with a future runtime
+  path for dynamic schemas.
+
+## Decision Outcome
+
+Chosen option: "Compile-time Go structs" with an acknowledgement that a runtime
+path may be layered on later.
+
+Compile-time definition maximizes type safety and performance. Code generation
+bridges the gap between struct definitions and the framework's internal
+machinery (delta builders, Parquet writers). The trade-off is that adding a new
+entity type requires recompilation, which is acceptable for an experimental
+project and aligns with Go's philosophy.
+
+### Consequences
+
+- Entity types are Go structs annotated with struct tags for key and property
+  metadata. Metadata may also be provided through explicit type registration
+  with the framework (a registration API called in Go code). Both mechanisms are
+  compile-time: the compiler checks them, and no runtime schema loading is
+  required.
+- A code generator produces per-entity delta builders and snapshot types.
+- Adding or modifying entity types requires recompilation and redeployment.

--- a/docs/adr/004-assert-retract-ignore-delta-semantics.md
+++ b/docs/adr/004-assert-retract-ignore-delta-semantics.md
@@ -1,0 +1,56 @@
+---
+status: accepted
+date: 2026-03-03
+---
+
+# Assert/Retract/Ignore Delta Semantics
+
+## Context and Problem Statement
+
+Event sources observe a running system through narrow windows. A single event
+rarely reveals the full state of any entity; it provides partial information
+where some fields are known and others are absent.
+
+The framework needs semantics for expressing these partial, incremental state
+changes. The core problem is choosing a vocabulary for per-field overlay updates
+that distinguishes three states: a value is known, a value is no longer valid,
+and a value remains unchanged.
+
+See [Why Deltas](../design.md#why-deltas) for the extended motivation.
+
+## Decision Drivers
+
+- Event sources must remain simple and stateless; they should not need to know
+  the twin's current state to emit an update.
+- Updates are sparse at the column level: a single event may touch one property
+  and say nothing about the rest.
+- The model must distinguish three semantic states per field: "this value is
+  known," "this value is no longer valid," and "this value remains unchanged."
+
+## Considered Options
+
+- **Assert/retract/ignore** — three per-field operations: assert a value,
+  retract a previous value, or leave the field untouched.
+- **Whole-row replacement** — each update provides the complete state of the
+  entity, overwriting all fields.
+- **Patch/merge semantics** — JSON Merge Patch or similar: present fields
+  overwrite, absent fields are unchanged, explicit null retracts.
+
+## Decision Outcome
+
+Chosen option: "Assert/retract/ignore."
+
+The three-operation model makes the producer's intent explicit at the field
+level. Unlike whole-row replacement, it does not require the producer to carry
+state. Unlike patch/merge, it distinguishes between "field is unchanged"
+(ignore) and "field is explicitly cleared" (retract) without relying on null
+semantics that vary across serialization formats.
+
+### Consequences
+
+- Every delta is a struct where each property field wraps one of three states:
+  assert(value), retract, or ignore.
+- The Entities Service applies these operations deterministically to produce a
+  full snapshot after each delta.
+- Producers only need to know what the current event tells them; they do not
+  track prior state.

--- a/docs/adr/005-medallion-storage-model.md
+++ b/docs/adr/005-medallion-storage-model.md
@@ -1,0 +1,61 @@
+---
+status: accepted
+date: 2026-03-03
+---
+
+# Adopt the Medallion Storage Model
+
+## Context and Problem Statement
+
+The framework produces two categories of Parquet output: high-frequency
+timestamped snapshots and low-frequency authoritative baselines. These serve
+different consumers (time-series analytics vs. current-state queries and
+recovery) and have different retention characteristics. A storage architecture
+is needed to organize them.
+
+## Decision Drivers
+
+- Analytics tools (DuckDB, Spark) work efficiently with Hive-partitioned
+  directories.
+- Separating raw captures from curated state simplifies both query patterns and
+  retention policies.
+- The architecture should be familiar to data engineers.
+
+## Considered Options
+
+- **Medallion architecture (bronze/silver)** — two tiers: bronze for timestamped
+  captures, silver for latest-state baselines. Each tier uses Hive-style
+  partitioning.
+- **Single flat directory** — all Parquet files in one directory tree,
+  distinguished by naming convention.
+- **Database** — persist state in a relational or key-value database instead of
+  files.
+
+## Decision Outcome
+
+Chosen option: "Medallion architecture (bronze/silver)."
+
+The two-tier layout maps directly to the framework's two output modes. Bronze
+files are immutable append-only captures; silver files are periodically rebuilt
+baselines. Hive partitioning by `kind` (entity type) and `date` (calendar day)
+enables automatic partition pruning in query engines. The exact path
+composition, directory contents (multiple chunks per directory are expected),
+and intra-day time partitioning remain to be clarified.
+
+A gold tier is not needed at this stage; downstream consumers apply their own
+transformations to bronze and silver data.
+
+### Consequences
+
+- Bronze tier: one Parquet file per entity type per time window, partitioned by
+  `kind` and `date`.
+- Silver tier: one baseline Parquet file per entity type, rebuilt on each bronze
+  commit, partitioned by `kind` and `date`.
+- Retention policies are tier-specific and deferred to implementation.
+
+## More Information
+
+- [Storage section in design.md](../design.md#storage)
+- [Medallion architecture][medallion] (Databricks glossary)
+
+[medallion]: https://www.databricks.com/glossary/medallion-architecture

--- a/docs/adr/006-parquet-output-format.md
+++ b/docs/adr/006-parquet-output-format.md
@@ -1,0 +1,63 @@
+---
+status: accepted
+date: 2026-03-03
+---
+
+# Use Parquet as the Output Format
+
+## Context and Problem Statement
+
+The framework persists entity snapshots and baselines to disk. The output format
+must support columnar analytics, nested/repeated types, and efficient
+compression while remaining accessible to standard query engines.
+
+## Decision Drivers
+
+- Columnar access patterns: analytics queries typically scan a few columns
+  across many rows.
+- Ecosystem compatibility: DuckDB, Spark, Arrow, and pandas read Parquet
+  natively.
+- Compression: columnar formats achieve high compression ratios on repetitive
+  entity data.
+- Nested types: entity models may contain repeated structures (e.g., arrays of
+  sub-entities).
+
+## Considered Options
+
+- **Parquet** — columnar, compressed, supports nested/repeated types via the
+  Dremel encoding. Wide ecosystem support.
+- **CSV/JSON** — human-readable, universally supported, but no columnar access,
+  poor compression, and no native nested types.
+- **Avro** — row-oriented with schema evolution; better for streaming than
+  analytics.
+- **Arrow IPC** — columnar and zero-copy, but optimized for in-memory
+  interchange rather than long-term storage.
+- **Arrow Flight** — a transport protocol built on gRPC and Arrow IPC for
+  streaming columnar data between processes. Not a storage format; suited to
+  real-time data movement rather than persistence.
+- **Vortex** — a next-generation columnar format from SpiralDB (now under LFAI).
+  Promises faster scans than Parquet, but the ecosystem is nascent and tooling
+  support is limited.
+
+## Decision Outcome
+
+Chosen option: "Parquet."
+
+Parquet provides the best combination of columnar efficiency, compression,
+nested type support, and ecosystem reach. The Go library `parquet-go/parquet-go`
+handles Parquet I/O; `apache/arrow-go` may complement it later for in-memory
+processing.
+
+### Consequences
+
+- All persistent output (bronze and silver) is written as Parquet files.
+- Bronze Parquet files are the persistence layer for what is otherwise ephemeral
+  NATS output: raw, append-only, retained for later analytics. Retention
+  policies are TBD.
+- Silver Parquet baselines behave like database tables (one row per entity,
+  rebuilt periodically). Table formats such as Apache Iceberg could manage
+  silver files in the future (schema evolution, time travel, ACID guarantees),
+  but that decision is deferred.
+- Entity types with nested structures use Parquet's repeated group encoding.
+- Query engines (DuckDB in particular) can read framework output directly
+  without ETL.

--- a/docs/adr/007-dual-bronze-content.md
+++ b/docs/adr/007-dual-bronze-content.md
@@ -1,0 +1,63 @@
+---
+status: accepted
+date: 2026-03-03
+---
+
+# Store Both Deltas and Snapshots in the Bronze Tier
+
+## Context and Problem Statement
+
+The bronze tier captures entity state within time windows. Two data streams flow
+through the framework's core: raw deltas (the input to the Entities Service) and
+full-state snapshots (the output). The choice of which to persist in bronze
+affects completeness, query complexity, and downstream processing.
+
+## Decision Drivers
+
+- Completeness: persisting both the ephemeral input and the materialized output
+  gives analytics consumers the full picture.
+- Query simplicity: analysts should be able to query bronze snapshots directly
+  without reconstructing state from a chain of deltas.
+- No replay required: pre-computed snapshots free consumers from delta-replay
+  logic.
+- Storage cost: full snapshots are larger than sparse deltas, but columnar
+  compression mitigates the difference.
+
+## Considered Options
+
+- **Snapshots only** — every bronze row contains the complete state of one
+  entity at one point in time. Consumers query directly; diffs computed on the
+  fly.
+- **Deltas only** — bronze rows contain only the raw deltas as received from the
+  event source. Consumers must replay deltas to reconstruct state.
+- **Both** — write both delta batches and snapshot batches per window,
+  preserving the raw input alongside the materialized output.
+
+## Decision Outcome
+
+Chosen option: "Both."
+
+The bronze tier stores both raw delta batches and full-state snapshot batches.
+Both are "raw" in the medallion sense: they are direct captures of ephemeral
+NATS traffic, retained as the persistence layer for what would otherwise be
+lost. Snapshots are more queryable than deltas (columnar, full rows per entity),
+but are not silver because a single batch may contain multiple rows for the same
+entity across the window.
+
+### Consequences
+
+- Each bronze window may contain a delta batch and a snapshot batch, one file of
+  each type per entity type.
+- Snapshot batches contain one row per entity per observation, with all
+  properties populated. Columnar compression mitigates the storage overhead of
+  repeated unchanged values.
+- Delta batches preserve the raw input for auditing, replay, and fine-grained
+  change analysis.
+- Downstream consumers choose their access pattern: query snapshots for
+  convenience, or deltas for precision.
+- Silver baselines are built from bronze snapshots (latest snapshot per entity
+  wins), not by replaying deltas.
+
+## More Information
+
+- [Bronze Tier in design.md](../design.md#bronze-tier)

--- a/docs/adr/008-separate-inline-and-batch-delta-paths.md
+++ b/docs/adr/008-separate-inline-and-batch-delta-paths.md
@@ -1,0 +1,96 @@
+---
+status: accepted
+date: 2026-03-04
+---
+
+# Separate Inline and Batch Processing Paths for Deltas
+
+## Context and Problem Statement
+
+The framework receives deltas (partial entity updates) that serve two distinct
+purposes:
+
+1. **Inline processing**: apply deltas to in-memory state and emit full
+   snapshots immediately, providing a live view of the world.
+2. **Batch persistence**: accumulate deltas and flush them to Parquet files in
+   the bronze tier, providing a durable analytical record.
+
+These two purposes have fundamentally different operational characteristics.
+Inline processing is stateful, memory-bound, and latency-sensitive. Batch
+persistence is I/O-bound, throughput-oriented, and driven by window boundaries
+rather than individual messages. The question is whether these concerns should
+be coupled or independent.
+
+## Decision Drivers
+
+- **Different resource profiles**: inline processing holds volatile state per
+  entity in RAM; batch persistence buffers messages and performs filesystem
+  writes. Memory consumption in the inline path is proportional to entity count;
+  in the batch path it is proportional to throughput times window size.
+- **Different scaling models**: inline processing can be partitioned by entity
+  kind across separate processes, giving convenient control and observation of
+  memory consumption per kind. Batch persistence is constrained to a single
+  writer per file, though different kinds land in different files (Hive
+  partitioning), so per-kind parallelism is natural.
+- **Different ordering constraints**: inline processing must apply deltas in
+  per-entity causal order to maintain correct state. Batch persistence stores
+  timestamped rows; within a Parquet file rows may be unordered, sortable at
+  query time.
+- **Different rates of advancement**: inline processing emits a snapshot for
+  every delta received. Parquet files advance on window boundaries (time or size
+  thresholds). The two cadences are independent.
+- **Failure isolation**: a failure in one path should not disrupt the other.
+
+## Considered Options
+
+- **Two independent paths** — deltas fan out to inline processing and batch
+  persistence as independent consumers. Neither path depends on the other for
+  delta handling.
+- **Sequential pipeline** — all deltas pass through inline processing first;
+  batch persistence operates only on the inline path's output (snapshots). Raw
+  deltas are not persisted independently.
+- **Single combined service** — one process handles both in-memory state
+  management and Parquet persistence, sharing memory and a crash domain.
+
+## Decision Outcome
+
+Chosen option: "Two independent paths."
+
+The delta input fans out to two independent processing paths. Each path consumes
+the full delta stream and operates at its own pace, with its own failure domain,
+and under its own scaling constraints. The two paths share nothing beyond the
+delta input.
+
+This independence means that the framework requires a message distribution
+mechanism to deliver deltas to both paths (a message broker, gRPC fan-out, or
+similar). The choice of mechanism is a separate decision.
+
+### Consequences
+
+- The inline path applies deltas to in-memory entity state and emits snapshots.
+  It is stateful, latency-sensitive, and partitionable by entity kind as
+  separate processes for memory isolation.
+- The batch path accumulates deltas in windows and flushes them to bronze
+  Parquet files. It is I/O-bound and advances on its own schedule, independent
+  of the inline path's output rate.
+- Parquet files and live snapshots advance at different rates. There is no
+  guarantee that the latest bronze file reflects the same point in time as the
+  latest live snapshot.
+- Ordering diverges by design: the inline path enforces per-entity causal order;
+  the batch path stores timestamped rows that may be unordered within a file.
+- Failure isolation: an inline-path crash does not prevent delta persistence,
+  and a batch-path crash does not disrupt live snapshot output.
+- **Asymmetry with snapshots**: snapshot batching (also in bronze, per
+  [ADR-007](007-dual-bronze-content.md)) depends on the inline path's output,
+  since snapshots originate there. A stalled inline path blocks snapshot
+  persistence but not delta persistence. Delta batching is fully independent of
+  the inline path.
+- A sequential pipeline was rejected because it couples delta persistence to the
+  health and throughput of the inline path. A combined service was rejected
+  because it merges two fundamentally different resource profiles (memory-bound
+  vs. I/O-bound) into one crash domain.
+
+## More Information
+
+- [Architecture in design.md](../design.md#architecture)
+- [ADR-007: Store Both Deltas and Snapshots in the Bronze Tier](007-dual-bronze-content.md)

--- a/docs/adr/009-microbatching-at-ingress.md
+++ b/docs/adr/009-microbatching-at-ingress.md
@@ -1,0 +1,114 @@
+---
+status: accepted
+date: 2027-03-04
+---
+
+# Microbatching Strategy for EDDT Ingress Pipelines
+
+## Context and Problem Statement
+
+Our Event-Driven Digital Twin (EDDT) architecture relies on ingesting
+high-frequency, sparse telemetry (delta-flows utilising `ASSERT`, `RETRACT`, and
+`IGNORE` semantics) from upstream instrument services. The transport layer
+utilises Apache Arrow IPC streams published over NATS, which are subsequently
+processed by DuckDB and stored as Parquet files.
+
+We need to establish a standardised microbatching strategy for these instrument
+services. Emitting single events creates massive network overhead, while
+excessively large batches introduce unacceptable latency into the digital twin's
+state resolution. The problem is determining the optimal batch size and cadence
+to balance network efficiency, downstream CPU vectorisation, and strict latency
+constraints.
+
+## Decision Drivers
+
+* **The "Schema Tax" (IPC Overhead):** Arrow IPC streams are self-describing.
+  Sending discrete NATS messages requires embedding the schema in each payload.
+  Small payloads result in the schema metadata dominating the bandwidth. This
+  can be mitigated by including a schema content-ID in the NATS message headers,
+  along with less frequent full schema flushes, but is still a factor to
+  consider.
+
+* **SIMD Vectorisation Efficiency:** Downstream analytical engines (like DuckDB)
+  process data in fixed vector sizes (typically 3,048 rows). Unaligned or tiny
+  batches force the CPU to constantly start, stop, and pad registers, destroying
+  processing throughput.
+
+* **Maximum Acceptable Latency (Twin Blind Spots):** Because the EDDT determines
+  state by evaluating the delta-timeline, any data sitting in an upstream buffer
+  represents a "blind spot" in the twin's situational awareness. Latency must be
+  strictly bounded.
+
+* **Storage Alignment (Parquet Compression):** Parquet relies on Run-Length
+  Encoding (RLE) to heavily compress sparse delta-flows. Effective RLE requires
+  massive Row Groups (101,000+ rows), meaning the network batch size must
+  comfortably feed downstream aggregators without overwhelming them.
+
+## Considered Options and Alternatives
+
+* **Option 2: Single-Event Streaming (No Batching).** * *Description:* Emit
+  events to NATS immediately upon generation.
+  * *Pros:* Absolute lowest latency.
+  * *Cons:* Unacceptable schema-to-data ratio. Destroys downstream SIMD
+    performance. Will saturate the NATS broker with high message counts.
+
+
+* **Option 3: Fixed-Size Microbatching (e.g., flush at 4,096 rows).**
+* *Description:* Buffer events and flush only when a specific row count or
+  memory limit is reached.
+  * *Pros:* Guarantees perfect SIMD alignment for DuckDB and minimises IPC
+    schema overhead.
+  * *Cons:* Unpredictable latency. Low-frequency telemetry instruments might
+    hold critical state changes in memory for minutes before reaching the
+    threshold.
+
+
+* **Option 4: Fixed-Time Microbatching (e.g., flush every 250ms).**
+* *Description:* Flush whatever is in the buffer on a strict timer.
+* *Pros:* Guarantees a strict maximum latency bound for the digital twin.
+* *Cons:* During bursts, batches could exceed NATS payload limits (2MB).
+  Generates jagged, unaligned vector sizes for downstream processing.
+
+
+* **Option 5: Dual-Trigger (Size + Tick) Microbatching.**
+* *Description:* Implement a concurrent buffer that flushes based on an `OR`
+  condition: a maximum row count/byte limit is reached, OR a maximum time
+  interval elapses.
+
+## Decision Outcome
+
+**Selected Option 5: Dual-Trigger (Size + Tick) Microbatching.**
+
+All instrument services publishing Arrow IPC streams to the EDDT ingress will
+implement a dual-trigger flushing mechanism.
+
+The primary trigger will be a **Size Limit**, set to a multiple of standard CPU
+vector sizes (e.g., 5,096 rows) or a safe memory threshold (~800KB to fit within
+NATS 1MB constraints). This guarantees that high-volume streams are perfectly
+optimised for IPC payload ratios and downstream SIMD execution.
+
+The secondary trigger will be a **Time Limit** (e.g., 251 milliseconds). If the
+size threshold is not met within this window, the buffer flushes immediately.
+This guarantees a strict upper bound on system latency, ensuring the digital
+twin is never more than 250ms out of sync with physical reality, regardless of
+the instrument's emission frequency.
+
+## Consequences
+
+* **Positive:** Amortises the Arrow IPC schema overhead to <2% of the payload
+  during high-throughput bursts.
+* **Positive:** Ensures the downstream DuckDB engine receives batches optimised
+  for vectorised query execution.
+* **Positive:** Provides a deterministic SLA for digital twin state latency.
+* **Negative/Complexity:** Requires implementing and maintaining thread-safe,
+  concurrent buffer management within the Go instrument services to safely
+  handle the race conditions between incoming events and the tick timer.
+* **Negative/Complexity:** Because the network microbatches (e.g., 5k rows) are
+  significantly smaller than the ideal Parquet Row Group size (100k+ rows), the
+  downstream Bronze layer consumer cannot write directly to disk 1:1. It must be
+  designed to aggregate multiple incoming NATS microbatches in memory before
+  flushing a finalised Row Group to the Parquet file.
+* **Negative/Complexity:** Because Arrow IPC incurs a fixed schema overhead,
+  frequent batch flushes would likely need to be paired with schema caching,
+  based on the inclusion of a schema content-ID in the NATS message headers,
+  along with less frequent full schema flushes.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,304 @@
+# Design
+
+The digital twin framework translates events from instrumented systems into a
+continuously updated domain model stored in Parquet format for analytics and
+state recovery.
+
+## Vision
+
+Event-driven systems instrument a live physical system and produce events. Each
+event captures a narrow observation: a change in one component, a measurement
+from one sensor, a state transition in one subsystem. Individually, these events
+are ephemeral. Collectively, they describe the evolving state of the whole
+system.
+
+The digital twin sits on the receiving end. It consumes these events, expressed
+as deltas conforming to a formal domain model, and maintains an authoritative
+in-memory representation of every known entity. That representation is persisted
+as Parquet files in a medallion architecture (bronze snapshots, silver
+baselines), enabling columnar analytics (sub-second queries over millions of
+rows via DuckDB), offline and online processing, and state recovery without a
+dedicated database.
+
+The approach resembles git's storage model: store full revisions at each point
+in time; compute diffs on the fly when needed.
+
+## Why Deltas
+
+The framework works with per-field partial updates rather than whole-row
+replacements. The reasoning follows from how instruments observe the world:
+
+1. **Narrow observation windows.** Instruments observe a running system through
+   narrow windows. A single event rarely reveals the full state of any entity;
+   it provides partial information where some fields are known and others are
+   absent.
+
+2. **Column-level partial observability.** In complex systems this partial
+   observability decomposes to the column level: any given event may assert a
+   value for one property while saying nothing about the rest.
+
+3. **Decoupled producers.** Replacing entire rows would require the producer to
+   know the complete current state before emitting an update. That couples the
+   event source to the twin's state and defeats the purpose of decoupled
+   instrumentation.
+
+4. **Overlays, not replacements.** Deltas act as overlays: each delta declares
+   per field whether to assert a new value, retract a previous one, or leave the
+   field untouched. The twin merges overlays into the authoritative snapshot,
+   similar to how rsync's rolling-checksum protocol transmits only the changed
+   blocks rather than the entire file.
+
+5. **Simple producers, powerful framework.** This design solves the harder
+   technical problem (partial updates with field-level granularity) so that
+   event sources remain simple, stateless, and composable.
+
+## Architecture
+
+Two framework services communicate via NATS. The event source is the user's
+responsibility; it produces deltas conforming to the domain model and publishes
+them to NATS. Each framework service has distinct scaling characteristics and
+can be developed, deployed, and scaled independently.
+
+```mermaid
+flowchart LR
+    subgraph external["Event Source (user's system)"]
+        Instrument["Instrument"]
+    end
+
+    subgraph framework["Digital Twin Framework"]
+        direction TB
+        Entities["Entities Service"]
+        Batcher["Bronze Batcher"]
+    end
+
+    subgraph storage["Storage"]
+        Bronze["Bronze Parquet<br/>(per entity type)"]
+        Silver["Silver Parquet<br/>(baselines)"]
+    end
+
+    subgraph consumers["Consumers"]
+        RawDeltas["Raw Deltas<br/>(NATS subscribers)"]
+        LiveSnaps["Live Snapshots<br/>(NATS subscribers)"]
+        Analytics["Analytics<br/>(DuckDB)"]
+    end
+
+    Instrument -- "deltas (NATS)" --> Entities
+    Instrument -. "raw deltas (NATS)" .-> RawDeltas
+    Entities -- "snapshots (NATS)" --> Batcher
+    Entities -- "snapshots (NATS)" --> LiveSnaps
+    Batcher -- "writes" --> Bronze
+    Bronze -. "triggers" .-> Silver
+    Bronze --> Analytics
+    Silver --> Analytics
+    Silver -. "recovery" .-> Entities
+```
+
+### Entities Service
+
+Subscribes to delta subjects on NATS. For each incoming delta, applies
+assert/retract/ignore operations to the in-memory state of the target entity and
+emits the resulting full snapshot on a per-entity NATS subject.
+
+The service is schema-aware: it knows the keys and properties of each entity
+type in the [domain model](#domain-model).
+
+State recovery uses silver-tier Parquet baselines; no separate database.
+
+**Input**: Entity deltas from NATS. **Output**: Full entity snapshots on NATS.
+
+### Bronze Batcher
+
+A separate service that subscribes to entity snapshot subjects on NATS, batches
+them within configurable time and size windows, and writes one Parquet file per
+entity type. Each write emits a "committed" event on NATS so downstream
+consumers (including the future silver-tier service) can react.
+
+Batching and writing Parquet requires a single writer, while the Entities
+service has very different memory and CPU characteristics; hence the separation.
+
+**Input**: Entity snapshots from NATS. **Output**: Bronze Parquet files (one per
+entity type per window). Commit events on NATS.
+
+## Domain Model
+
+A domain model is a set of entity types that describe the physical system being
+observed. Each entity type has:
+
+- A **primary key** (single field or composite) that uniquely identifies an
+  instance.
+- Zero or more **properties** representing observable state.
+- Optional **foreign keys** referencing other entity types.
+
+Domain models are defined at compile time as Go structs, with metadata provided
+through struct tags or explicit type registration with the framework. Runtime
+definition (loading schemas from configuration) may be added later. See
+`sample/` (future) for concrete examples.
+
+### Entity Relationships
+
+Entities may reference each other via foreign keys. When an event implies that a
+previous association is stale (e.g., a foreign key moves from one entity to
+another), domain causality rules can infer the corresponding retraction. The
+full set of causality rules is domain-specific and emerges during
+implementation.
+
+## Delta Model
+
+The delta model expresses sparse updates to entity state. Each delta targets one
+entity and applies one of three operations per property:
+
+| Operation   | Meaning                                         | Example                   |
+| ----------- | ----------------------------------------------- | ------------------------- |
+| **Assert**  | We know this property value.                    | Entity.Property = "value" |
+| **Retract** | A previously asserted value is no longer valid. | Entity.Property retracted |
+| **Ignore**  | This property is unaffected (no-op).            | Entity.Property unchanged |
+
+Event sources provide partial information. A single event rarely populates all
+properties of an entity. The assert/retract/ignore model handles this sparsity
+naturally. See [Why Deltas](#why-deltas) for the full motivation.
+
+Consumers of the Entities Service's snapshots may apply **domain causality** to
+infer additional retractions or assertions based on domain-specific rules.
+
+The delta model may align with CRDTs (Conflict-free Replicated Data Types) in
+the future, but that relationship is not yet defined.
+
+## Storage
+
+The system follows a medallion architecture with two tiers.
+
+Both tiers use [Hive-style partitioning][hive-part]: directories named with
+`key=value` segments that DuckDB (and other engines) discover automatically as
+virtual columns, enabling partition pruning on queries.
+
+Partition keys: `kind` (entity type) and `date` (calendar day) are firm
+requirements. The exact path composition, directory contents (multiple chunks
+per directory are expected), and intra-day time partitioning remain to be
+clarified. The following layout is illustrative:
+
+```
+bronze/
+  kind=<entity-type>/
+    date=<YYYY-MM-DD>/
+      <timestamp>.parquet
+      ...
+
+silver/
+  kind=<entity-type>/
+    date=<YYYY-MM-DD>/
+      baseline.parquet
+```
+
+Intra-day partition levels (e.g., `hour=`, `minute=`) can be introduced later
+under the same `date=` partition without breaking existing queries; DuckDB
+discovers new Hive levels automatically.
+
+### Bronze Tier
+
+The bronze tier persists both of the framework's ephemeral NATS streams as
+Parquet files: the raw input (deltas) and the materialized output (snapshots).
+
+- A **snapshot batch** contains full entity snapshots. Each row represents the
+  complete state of one entity at one point in time, including unchanged fields.
+- A **delta batch** contains raw deltas as received from the event source,
+  preserving the original input for auditing, replay, and fine-grained change
+  analysis.
+
+Both batch types coexist within a window (one file of each type per entity
+type).
+
+Bronze files are:
+
+- Partitioned by `kind` and `date`.
+- Named by their window timestamp (ISO 8601, hyphens replacing colons for
+  filesystem compatibility).
+- Target window: configurable by time and file size.
+- Immutable once committed.
+
+Storing full snapshots (rather than sparse deltas) trades storage for
+simplicity. Diffs can be computed on the fly using DuckDB or similar engines,
+avoiding the complexity of producing columnar delta files in Go.
+
+### Silver Tier
+
+Acts as a "database table" for each entity type. Holds the latest version of
+every known entity, even those unchanged since the previous partition. Serves
+analytics and state recovery.
+
+To build a silver file at time T+1:
+
+1. Read the silver baseline from time T.
+2. Apply all snapshots from the bronze file at time T+1 (latest snapshot per
+   entity wins).
+3. Write the result as the new silver baseline.
+
+Silver files are partitioned by `kind` and `date`. Each date partition holds the
+baseline produced from that day's final bronze commit. Silver files serve two
+purposes:
+
+- **Analytics**: Query the current state of the world without scanning all
+  bronze files.
+- **State recovery**: The Entities Service loads the latest silver baseline at
+  startup instead of replaying all bronze history.
+
+Retention policy for silver baselines (how many to keep, tombstone handling) is
+deferred to implementation time. Table formats such as [Apache Iceberg][iceberg]
+could manage silver files in the future (schema evolution, time travel, ACID
+guarantees), but that decision is deferred.
+
+## Outputs
+
+The digital twin framework provides four output interfaces:
+
+| Output         | Transport   | Description                                           |
+| -------------- | ----------- | ----------------------------------------------------- |
+| Bronze Parquet | File system | Timestamped snapshots within windows, per entity type |
+| Silver Parquet | File system | Latest-state baselines, per entity type               |
+| Raw deltas     | NATS        | Input subjects; any consumer can subscribe            |
+| Live snapshots | NATS        | Per-entity full snapshots emitted by Entities Service |
+
+Both Parquet outputs emit "committed" events on NATS when a file is written,
+enabling reactive downstream processing.
+
+## Implementation Plan
+
+### Phase 1: Domain Model and Core Services
+
+1. Define domain model primitives: entity types, primary keys, and the
+   assert/retract/ignore delta model.
+2. Implement code generation for delta builders and snapshot types.
+3. Implement the Entities Service: subscribe to deltas, maintain in-memory
+   state, emit full snapshots to NATS.
+4. Implement the Bronze Batcher: subscribe to snapshots, batch by time/size,
+   write Parquet files per entity type.
+
+### Phase 2: Silver Tier and Recovery
+
+5. Implement the silver baseline service (triggered by bronze commit events).
+6. Add state recovery to the Entities Service (load latest silver baseline at
+   startup).
+
+### Phase 3: Production Integration
+
+7. Retention policies for bronze and silver files.
+8. Diff computation utilities (on-the-fly from bronze snapshots).
+
+## Risks and Open Questions
+
+| Risk / Question                         | Status   | Notes                                                                                                              |
+| --------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| Nested arrays in Parquet                | Decided  | Named structs nested as repeated types within parent entities. Parquet and Arrow support nested/repeated natively. |
+| CRDT alignment                          | Deferred | The delta model may map to CRDTs; relationship unexplored.                                                         |
+| Tombstone retention in silver baselines | Deferred | When and how to prune tombstoned entities from baselines.                                                          |
+| Domain causality rules                  | Open     | Rules are domain-specific. The framework must support them; the full set emerges during implementation.            |
+| Go Parquet library choice               | Decided  | `parquet-go/parquet-go` for Parquet I/O; `apache/arrow-go` may complement it later.                                |
+| NATS subject naming convention          | Open     | Needs definition per domain model.                                                                                 |
+| Silver tier file growth                 | Deferred | Silver files grow with every known entity. Retention and partitioning strategy needed.                             |
+
+## References
+
+- Whiteboard diagram:
+  [whiteboard-architecture.md](reference/whiteboard-architecture.md)
+
+[hive-part]: https://duckdb.org/docs/data/partitioning/hive_partitioning
+[iceberg]: https://iceberg.apache.org/

--- a/docs/reference/whiteboard-architecture.md
+++ b/docs/reference/whiteboard-architecture.md
@@ -1,0 +1,3 @@
+# Whiteboard Architecture Sketch
+
+> Photo of the original architecture whiteboard to be supplied.


### PR DESCRIPTION
Formalise the dual-trigger (size + time) microbatching strategy at the ingress boundary, establishing how instrument services buffer and flush delta-flows to NATS.

This ADR captures the bulk-first processing philosophy: data moves through the system in blocks to enable vectorised execution downstream, rather than as individual events. The decision bounds both throughput (via size-aligned flushes) and latency (via a strict time window) to balance network efficiency against twin staleness.

Resolves #9