### PR TITLE
Define sample domain model for shared electric scooters

### DIFF
--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -1,0 +1,79 @@
+// Package fingerprint defines reusable types for classification assertions in
+// digital twin domain models.
+//
+// Classification entities represent competing inferences: multiple classifiers
+// may simultaneously assert different values for the same entity. Domain models
+// embed [Classification] to standardize the fingerprint metadata pattern.
+//
+// [Classification] is designed for embedding (anonymous field). When embedded,
+// its fields are promoted to the parent entity:
+//
+//   - [Classification.Source] becomes part of the composite primary key
+//     (alongside the entity's own foreign key). A [Signature] identifies a
+//     specific classifier by type and deployment: two classifiers with
+//     different sources can assert different values for the same entity.
+//   - [Classification.Active], [Classification.Confidence], and
+//     [Classification.TTL] are regular properties with individual delta
+//     operations.
+//
+// [Signature] is a named struct field: it is provided as a whole value when
+// used as a key component in a delta constructor, and replaced atomically
+// when used as a property.
+package fingerprint
+
+import "time"
+
+// Classification holds metadata common to all classification assertions.
+//
+// Domain model types embed this struct to gain the standard fingerprint fields.
+// Because it is an anonymous (embedded) field, [Source] is promoted to the
+// parent entity and serves as part of the composite primary key alongside the
+// entity's own foreign key.
+//
+// Scalar fields (Active, Confidence, TTL) each get their own delta operations.
+type Classification struct {
+	// Source identifies which classifier produced this assertion. The full
+	// signature (Type + Instance) forms part of the composite primary key:
+	// different classifier types, and different deployments of the same type,
+	// each maintain their own row for the same entity.
+	Source Signature
+
+	// Active distinguishes production classifiers from those under evaluation.
+	// Downstream actions (alerts, policy enforcement) typically filter on
+	// Active == true. Keeping evaluation classifiers visible in the same table
+	// enables side-by-side comparison without a separate pipeline.
+	Active bool
+
+	// Confidence is the classifier's self-reported certainty in the range
+	// [0.0, 1.0]. Downstream consumers can threshold or rank by confidence
+	// when multiple classifiers disagree.
+	Confidence float64
+
+	// TTL is the validity window for this assertion. If the classifier does
+	// not re-assert within this duration, the classification should be
+	// considered stale. How staleness is measured and enforced is up to the
+	// application. A zero value means the assertion does not expire.
+	TTL time.Duration
+}
+
+// Signature identifies a specific classifier by type and deployment. The full
+// value (Type + Instance) is the classifier's identity within the domain
+// model: each unique signature produces its own classification row.
+//
+// Type is the stable classifier name; Instance is a catch-all string for
+// deployment-specific taxonomy that may become more structured over time
+// (version tags, region identifiers, build hashes, experiment labels).
+type Signature struct {
+	// Type identifies the kind of classifier: a stable name known to the
+	// system that groups all deployments of the same classification logic.
+	//
+	// Examples: "dns-fingerprint", "imsi-range", "payload-analysis".
+	Type string
+
+	// Instance identifies a specific deployment, version, or configuration of
+	// the classifier named by Type. This is intentionally a free-form string
+	// to accommodate the various ways classifier deployments are versioned.
+	//
+	// Examples: "v2.3", "prod-us-east-1", "experimental-2026Q1".
+	Instance string
+}

--- a/samples/micromobility/README.md
+++ b/samples/micromobility/README.md
@@ -1,0 +1,497 @@
+# Shared Electric Scooters
+
+This sample domain models shared electric scooters (Lime, Bird, Dot and similar
+operators) as seen from a cellular network observation platform. The platform does
+not have access to any operator's fleet management system. Everything it knows
+about the scooters, it learns from the network.
+
+## The World
+
+A city has thousands of electric scooters deployed across sidewalks, docking
+stations, and street corners. Several operators compete in the same geography:
+Lime, Bird, Dot, and others. Each operator manages its own fleet independently,
+but all their scooters share the same cellular infrastructure to reach their
+backends.
+
+### Scooters
+
+A scooter is a small electric vehicle built around a control board running the
+operator's firmware. The board reads sensors (GPS receiver, accelerometer, BMS
+interface) and runs the application logic that decides what to report, when to
+report it, and how to encode the telemetry payload. Think of it as a small
+embedded computer with peripherals.
+
+Connectivity is one of those peripherals. The scooter's software sends its
+telemetry through whatever network interface is available: a built-in cellular
+modem, a Bluetooth bridge to the rider's phone, WiFi at a docking station, or
+some combination. The modem, when present, is a communication channel, not the
+brain. It provides an IP interface to the scooter's software much like an
+Ethernet adapter on a server.
+
+Scooters carry a VIN stamped on the frame and a QR code for riders to scan. From
+the operator's perspective, these are the primary identifiers. From the network's
+perspective, the scooter itself is invisible; only the network interface's
+identifiers (IMEI, IMSI, IP for cellular; the phone's identifiers for
+Bluetooth-bridged scooters) are visible.
+
+### Modems and eSIMs
+
+Scooters that have a built-in cellular modem carry two permanent hardware
+identifiers: an IMEI (the modem) and an EID (the eUICC chip that stores eSIM
+profiles). The active eSIM profile adds two more: an ICCID (the profile itself)
+and an IMSI (the subscriber identity the network uses for authentication and
+routing). The network assigns a dynamic IP address when the modem establishes a
+data session.
+
+These identifiers have different lifetimes. The IMEI and EID are etched at
+manufacture and never change. The ICCID and IMSI are tied to the active eSIM
+profile; they change when the operator remotely provisions a new profile, for
+example to switch carriers for better regional coverage. The IP address is
+ephemeral, reassigned on every new data session.
+
+### Batteries
+
+Scooters run on swappable lithium-ion battery packs. Each pack has a serial
+number printed on its casing and a small BMS (battery management system) chip
+that reports charge level and cycle count through the scooter's telemetry payload.
+Field technicians swap batteries in the street: they pull the depleted pack,
+insert a fresh one, and move on. A single battery may pass through dozens of
+scooters over its lifetime.
+
+### Riders and Rides
+
+A rider unlocks a scooter through the operator's app, rides to a destination, and
+parks it. From the network side, a ride looks like a burst of frequent telemetry
+beacons with non-zero speed and changing GPS coordinates. The ride itself is a
+business concept managed by the operator's backend; the network never sees a
+"ride started" or "ride ended" event directly. It can only infer ride activity
+from the telemetry pattern.
+
+### Field Technicians
+
+Operators employ field technicians (sometimes called "juicers" or "chargers") who
+drive vans through the city collecting scooters with low batteries, swapping
+packs, relocating scooters to high-demand areas, and performing maintenance. From
+the network's perspective, a battery swap manifests as a sudden change in the
+battery serial number reported in the telemetry payload. A relocation looks like a
+GPS jump while the scooter is not in a ride.
+
+## How Scooters Connect
+
+Not all scooters connect the same way. The connectivity model varies by operator,
+hardware generation, and cost trade-offs. This variance directly affects what the
+observation platform can see and how reliably it can track each scooter.
+
+### Cellular (always-on modem)
+
+The richest observability scenario. The scooter has a built-in cellular modem with
+an eSIM. It maintains a persistent data session even when idle: the modem is
+always attached to the network, the IP address is allocated, and the scooter's
+software sends periodic heartbeats regardless of ride activity. The platform sees
+the modem's IMEI and IMSI at the network layer and correlates them with the
+application-layer telemetry flowing through the session.
+
+This is the primary scenario explored in this domain model.
+
+### Phone-bridged (Bluetooth relay)
+
+Some operators (or earlier hardware generations) save the cost of a cellular modem
+by having the scooter communicate through the rider's phone. The scooter connects
+to the phone via Bluetooth Low Energy; the phone relays telemetry to the
+operator's backend over its own cellular connection.
+
+From the platform's perspective, the scooter is invisible between rides. During a
+ride, the platform sees the *phone's* IMEI, IMSI, and IP, not the scooter's. The
+application payload still contains the scooter's device ID and sensor readings,
+but the network-layer anchor belongs to the phone and changes with every rider.
+The platform can extract telemetry but cannot maintain a persistent identity for
+the scooter across rides.
+
+### Hybrid
+
+Some operators use both: a cellular modem for always-on fleet management and a
+Bluetooth connection to the rider's phone for real-time ride features (unlock,
+lock, in-ride UI). The platform sees both the modem's session and the phone's
+session. Correlating the two (same scooter, two network identities) is a
+non-trivial classification problem.
+
+### WiFi at dock
+
+A few operators equip docking stations with WiFi. Scooters connect when docked
+and upload buffered telemetry in bulk. The platform sees intermittent bursts of
+data with long gaps between them. The WiFi MAC address is a per-station
+identifier, not a per-scooter one.
+
+### Why This Variance Matters
+
+The observation platform must handle all of these modes. A scooter with an
+always-on cellular modem produces a continuous, rich data stream. A
+phone-bridged scooter produces ride-time-only fragments with a shifting network
+anchor. A WiFi-docked scooter produces delayed batches. The domain model
+accommodates this through two mechanisms:
+
+1. **Layered identity.** The Modem and Vehicle are separate entities observed
+   through different channels. For cellular-connected scooters, both entities
+   exist and are correlated. For phone-bridged scooters, the platform may only
+   have the Vehicle (from extracted application payloads) without a stable Modem
+   anchor. The model does not require both.
+
+2. **Partial data.** The assert/retract/ignore delta semantics handle gaps
+   naturally. The platform asserts what it knows, ignores what it does not, and
+   retracts what has gone stale. A phone-bridged scooter with no telemetry
+   between rides simply has its ephemeral properties retracted by timeout.
+
+## What the Network Sees
+
+The observation platform sits at the cellular network layer. It sees data
+sessions, IP assignments, and DNS queries. It does not see app-level events (ride
+start, payment, user account) because those are encrypted end-to-end between the
+scooter's software and its operator's cloud.
+
+What the platform can observe directly:
+
+- **Network layer** (from the cellular infrastructure): IMEI and IMSI when the
+  modem attaches, IP address when a session is established, serving cell identity
+  and signal strength.
+- **DNS queries** when the scooter's software resolves its operator's API domain
+  (e.g., `api.lime.com`, `device.bird.co`).
+- **Application layer** (from intercepted telemetry payloads): device ID, GPS
+  coordinates, speed, battery serial and state of charge, accelerometer status,
+  and the trigger that caused this particular report.
+
+The network layer and application layer are observed independently and correlated
+by the platform. For cellular-connected scooters, the correlation is
+straightforward: the application payload flows through the modem's IP session. For
+phone-bridged scooters, the application payload flows through the rider's phone,
+and the network-layer identity belongs to the phone.
+
+## Telemetry Events
+
+The scooter's software (not the modem) controls telemetry: what to report, when
+to report it, and how to encode it. The specifics vary by operator and firmware
+generation, but the general patterns are consistent across the industry.
+
+### Payload Structure
+
+Each telemetry report carries a common envelope and a set of sensor readings. The
+fields below use standard abbreviations from IoT and vehicle telematics:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `device_id` | string | Scooter identity (VIN or operator-assigned fleet ID) |
+| `ts` | ISO 8601 | Timestamp at the scooter's clock |
+| `seq` | uint32 | Monotonic sequence number; gaps reveal lost reports |
+| `trigger` | string | Why this report was sent (see [Triggers](#triggers)) |
+| `gnss.lat`, `gnss.lng` | float64 | WGS 84 coordinates |
+| `gnss.alt` | float64 | Altitude in meters above sea level |
+| `gnss.hdop` | float64 | Horizontal dilution of precision (lower is better) |
+| `gnss.sats` | uint8 | Satellites used in the fix |
+| `gnss.fix` | string | Fix quality: `"none"`, `"2d"`, `"3d"` |
+| `speed` | float64 | Ground speed in km/h (GNSS-derived) |
+| `heading` | float64 | Course over ground in degrees, 0–360 |
+| `battery.id` | string | BMS-reported serial number of the installed pack |
+| `battery.soc` | float64 | State of charge, 0.0–1.0 |
+| `battery.voltage` | float64 | Pack voltage in volts |
+| `battery.temp` | int | Cell temperature in °C |
+| `battery.cycles` | uint32 | Lifetime charge cycle count |
+| `odometer` | float64 | Cumulative trip distance in km |
+| `cell.mcc` | uint16 | Mobile Country Code of the serving cell |
+| `cell.mnc` | uint16 | Mobile Network Code |
+| `cell.cid` | uint32 | Cell ID |
+| `cell.rsrp` | int | Reference Signal Received Power in dBm |
+| `accel.motion` | bool | Accelerometer motion detection flag |
+| `accel.tilt` | float64 | Tilt angle in degrees (0 = upright, 90 = on its side) |
+
+Not every field is present in every report. The scooter's software omits fields
+it cannot populate (e.g., `gnss.*` when there is no satellite fix) or fields
+irrelevant to the trigger (e.g., `cell.*` may be absent on phone-bridged
+scooters).
+
+The `device_id` is the application-layer identity of the scooter. It is
+independent of the IMEI: the IMEI belongs to the modem at the network layer,
+while the `device_id` belongs to the scooter's software at the application layer.
+The platform correlates the two by observing which `device_id` payloads flow
+through which IMEI's IP session.
+
+### Triggers
+
+The `trigger` field records why this report was emitted. Reports are either
+periodic (fired on a timer) or edge-triggered (fired by a state change detected
+by the scooter's software):
+
+**Periodic:**
+
+| Trigger | Cadence | Condition |
+|---------|---------|-----------|
+| `periodic` | 60–120 s | Scooter is idle (no motion detected) |
+| `periodic` | 2–5 s | Scooter is in motion (ride in progress) |
+
+The cadence is governed by the scooter's firmware. The same trigger value
+covers both idle and ride modes; the platform infers the scooter's state from
+the reporting frequency and the `accel.motion` flag.
+
+**Edge-triggered:**
+
+| Trigger | Fired when |
+|---------|------------|
+| `motion_start` | Accelerometer transitions from stationary to moving |
+| `motion_stop` | Accelerometer transitions from moving to stationary |
+| `impact` | Accelerometer spike exceeds impact threshold (fall or collision) |
+| `battery_swap` | BMS reports a different battery serial after power cycle |
+| `low_battery` | State of charge drops below configured threshold |
+| `cell_change` | Serving cell changes (handover between towers) |
+| `gnss_fix` | GNSS acquires a fix after a period with no fix |
+| `power_on` | Scooter boots after battery insertion or deep sleep wake |
+
+Edge-triggered reports are sent immediately, independently of the periodic timer.
+A burst of events can occur in quick succession (e.g., `power_on` followed by
+`battery_swap` followed by `gnss_fix` within seconds of a battery replacement).
+
+### Reporting Cadence Over Time
+
+```
+          power_on  motion_start       periodic (ride)         motion_stop
+              │         │          ┌──────────┬──────────┐         │
+  ──idle──────┼─────────┼──ride────┼──ride────┼──ride────┼─────────┼──idle─────
+  60s    60s  ▼    60s  ▼  3s  3s  ▼  3s  3s  ▼  3s  3s  ▼   3s   ▼  60s   60s
+  ·      ·    ·    ·    ·  · · · · ·  · · · · ·  · · · · ·   · ·  ·  ·     ·
+```
+
+## A Scooter's Day
+
+The following traces one cellular-connected scooter through a full day. This is
+the richest observability scenario; phone-bridged scooters would produce a sparser
+sequence (telemetry only during rides, no persistent modem identity, longer gaps).
+
+### Early Morning
+
+Scooter `WMX00042` sits idle near a docking station at Rothschild Boulevard. Its
+modem (IMEI `353456789012345`) has been connected since last night with IP
+`100.72.14.201`. Battery `BAT-1042` is at 12% after a long evening of rides.
+
+The scooter's software sends idle heartbeats every 90 seconds:
+
+```
+{device_id: "WMX00042", ts: "06:12:04Z", seq: 81040, trigger: "periodic",
+ gnss: {lat: 32.0636, lng: 34.7748, fix: "3d", hdop: 1.1, sats: 9},
+ speed: 0, heading: 0,
+ battery: {id: "BAT-1042", soc: 0.12, voltage: 36.1, temp: 18, cycles: 487},
+ accel: {motion: false, tilt: 2.1}}
+```
+
+A field technician pulls up in a van, pops the battery latch, and swaps
+`BAT-1042` for a fresh pack `BAT-2187`. The scooter powers down momentarily and
+comes back up. Three edge-triggered events fire in rapid succession:
+
+```
+{device_id: "WMX00042", ts: "06:14:31Z", seq: 81041, trigger: "power_on",
+ battery: {id: "BAT-2187", soc: 0.97, voltage: 42.0, temp: 22, cycles: 31},
+ accel: {motion: false, tilt: 3.0}}
+
+{device_id: "WMX00042", ts: "06:14:31Z", seq: 81042, trigger: "battery_swap",
+ battery: {id: "BAT-2187", soc: 0.97, voltage: 42.0, temp: 22, cycles: 31}}
+
+{device_id: "WMX00042", ts: "06:14:38Z", seq: 81043, trigger: "gnss_fix",
+ gnss: {lat: 32.0636, lng: 34.7748, fix: "3d", hdop: 1.3, sats: 7},
+ battery: {id: "BAT-2187", soc: 0.97, voltage: 42.0, temp: 22, cycles: 31},
+ accel: {motion: false, tilt: 2.4}}
+```
+
+Note: the `power_on` event has no GNSS data because the receiver has not acquired
+a fix yet. The `battery_swap` event fires once the scooter's software detects the
+new battery serial. The `gnss_fix` event follows a few seconds later when
+satellites are reacquired.
+
+In the platform's model, `BAT-2187` is now associated with `WMX00042`, and
+`BAT-1042` has no vehicle association until it appears in another scooter.
+
+### Morning Commute
+
+At 08:14, a rider unlocks the scooter through the Lime app. The scooter's
+software detects motion:
+
+```
+{device_id: "WMX00042", ts: "08:14:02Z", seq: 81099, trigger: "motion_start",
+ gnss: {lat: 32.0636, lng: 34.7748, fix: "3d", hdop: 0.9, sats: 11},
+ speed: 0.3, heading: 355,
+ battery: {id: "BAT-2187", soc: 0.94, voltage: 41.8, temp: 26, cycles: 31},
+ odometer: 0.0,
+ accel: {motion: true, tilt: 1.8}}
+```
+
+The reporting cadence jumps to every 3 seconds. As the rider heads north along
+Dizengoff Street, periodic ride telemetry flows:
+
+```
+{.., ts: "08:14:05Z", seq: 81100, trigger: "periodic",
+ gnss: {lat: 32.0638, lng: 34.7747, ..}, speed: 5.2, heading: 358,
+ battery: {id: "BAT-2187", soc: 0.94, ..}, odometer: 0.01, ..}
+
+{.., ts: "08:14:08Z", seq: 81101, trigger: "periodic",
+ gnss: {lat: 32.0643, lng: 34.7746, ..}, speed: 12.7, heading: 2, ..}
+
+{.., ts: "08:14:11Z", seq: 81102, trigger: "periodic",
+ gnss: {lat: 32.0651, lng: 34.7745, ..}, speed: 17.8, heading: 1, ..}
+```
+
+The platform asserts Speed and Location on each beacon and detects the sustained
+movement pattern, setting InRide to true.
+
+Meanwhile, at the network layer, the scooter's modem resolves `api.lime.com`. A
+DNS-based classifier asserts that IMEI `353456789012345` is operated by Lime with
+0.92 confidence. An IMSI-range analyzer recognizes the IMSI prefix `42501...` as
+a Lime-contracted SIM plan and asserts the same operator at 0.71 confidence. A
+payload-structure classifier recognizes the telemetry encoding as Segway Max G30
+firmware and asserts a model classification. Three classifiers, three independent
+assertions, all keyed on the same IMEI.
+
+### Mid-Ride: Cell Handover
+
+The rider crosses into a different cell sector. The network hands over the
+session. The scooter's software detects the cell change:
+
+```
+{device_id: "WMX00042", ts: "08:22:17Z", seq: 81244, trigger: "cell_change",
+ gnss: {lat: 32.0812, lng: 34.7801, fix: "3d", hdop: 0.8, sats: 12},
+ speed: 16.4, heading: 12,
+ battery: {id: "BAT-2187", soc: 0.91, ..},
+ cell: {mcc: 425, mnc: 01, cid: 52417, rsrp: -78},
+ accel: {motion: true, ..}}
+```
+
+At the network layer, the IP changes from `100.72.14.201` to `100.72.31.88`.
+The IMEI and IMSI remain the same. The platform asserts the new IP on the Modem
+entity; the old IP is overwritten by the new assertion.
+
+### Ride Ends
+
+At 08:31, the rider parks near Rabin Square and locks the scooter:
+
+```
+{device_id: "WMX00042", ts: "08:31:44Z", seq: 81420, trigger: "motion_stop",
+ gnss: {lat: 32.0873, lng: 34.7811, fix: "3d", hdop: 0.9, sats: 10},
+ speed: 0, heading: 15,
+ battery: {id: "BAT-2187", soc: 0.88, voltage: 41.2, temp: 30, cycles: 31},
+ odometer: 3.7,
+ accel: {motion: false, tilt: 2.0}}
+```
+
+The scooter's software drops back to idle cadence: one heartbeat every 90
+seconds. The platform's ride detector sees the transition from high-frequency
+motion telemetry to low-frequency idle heartbeats and sets InRide to false.
+
+### Afternoon: Silence and Staleness
+
+By 14:00, six hours have passed without a ride. The scooter is still sending
+idle heartbeats (speed 0, same location), keeping its properties fresh:
+
+```
+{device_id: "WMX00042", ts: "14:00:12Z", seq: 81783, trigger: "periodic",
+ gnss: {lat: 32.0873, lng: 34.7811, fix: "3d", ..},
+ speed: 0,
+ battery: {id: "BAT-2187", soc: 0.85, ..},
+ accel: {motion: false, tilt: 2.0}}
+```
+
+Now imagine the scooter gets moved into a parking garage by an overzealous
+building manager. The GNSS fix degrades, then disappears. The cellular signal
+weakens. Eventually, the scooter's software cannot send at all:
+
+```
+{device_id: "WMX00042", ts: "14:15:42Z", seq: 81793, trigger: "periodic",
+ gnss: {fix: "none"},
+ battery: {id: "BAT-2187", soc: 0.84, ..},
+ cell: {mcc: 425, mnc: 01, cid: 52418, rsrp: -112},
+ accel: {motion: false, tilt: 2.1}}
+
+... then silence.
+```
+
+After the configured telemetry TTL expires (say, 15 minutes with no beacon), the
+platform retracts Speed, Location, and InRide. The scooter still exists in the
+model (VIN, IMEI association, battery serial are stable facts), but its ephemeral
+properties are gone. The platform knows the scooter exists; it does not know where
+it is or what it is doing.
+
+Note the last report: the GNSS fix was `"none"` but the battery and accelerometer
+data were still valid. The scooter's software sent what it could. The platform
+asserted the battery level and retracted the location (no fix means no
+coordinates). Partial data is normal.
+
+If the IP session also times out on the network side, the platform retracts IP
+from the Modem entity. The IMEI, EID, ICCID, and IMSI remain: they are facts
+about the hardware and its profile, not about the current session.
+
+### Evening: eSIM Reprovisioning
+
+The operator decides to switch carrier for better evening coverage in the city
+center. A remote eSIM management platform pushes a new profile to the eUICC. The
+ICCID and IMSI change; the old data session is torn down. The platform sees the
+new IMSI appear on the same IMEI and asserts the updated profile identifiers.
+Because the old IP belonged to the previous profile's session, it is retracted.
+The EID stays the same: the eUICC chip did not change, only the profile stored on
+it.
+
+This is not a telemetry event. It is a network-layer observation: the platform
+sees the IMEI re-attach with a different IMSI. No application payload is involved.
+
+### Decommission
+
+Months later, `WMX00042` is retired from the fleet. The operator stops sending
+commands; the scooter stops reporting. Its ephemeral properties are retracted by
+timeout. Its stable properties (VIN, IMEI association) remain in the model
+indefinitely as historical record, until explicitly retracted by an
+administrative event.
+
+## Competing Knowledge
+
+Not everything the platform knows is certain. When two classifiers assert
+different operators for the same modem (say, the DNS classifier sees `lime.com`
+but the IMSI-range analyzer maps the prefix to Bird), both assertions coexist.
+Each has its own source identifier, confidence score, and deployment version.
+Downstream consumers decide how to reconcile: pick the highest confidence, require
+agreement, or flag the conflict.
+
+This is not a bug; it is a feature of the domain. The real world is ambiguous.
+Scooters are reflashed and resold between operators. SIM plans are occasionally
+shared across brands. Classifiers are imperfect and versioned: today's
+`dns-fingerprint v2.3` might be replaced by `v3.0` next quarter with different
+accuracy characteristics. The domain model holds all perspectives simultaneously
+rather than forcing premature resolution.
+
+## Variance
+
+The scooter domain has many axes of variation, and the platform must handle them
+all without requiring a uniform data source.
+
+| Axis | Range | Effect on observability |
+|------|-------|------------------------|
+| **Operator** | Lime, Bird, Dot, others | Different firmware, payload formats, reporting intervals |
+| **Hardware generation** | Gen 1 (BLE-only) through Gen 4 (cellular + BLE) | Gen 1 has no modem; no persistent network identity between rides |
+| **Connectivity** | Cellular, phone-bridged, hybrid, WiFi-at-dock | Determines whether a stable Modem entity exists |
+| **Carrier** | Multiple MNOs per region | Different IMSI prefixes, APN configurations, IP address pools |
+| **Coverage** | Full signal to dead zones | Observation gaps; properties go stale at different rates |
+| **Firmware version** | Operator-specific, updated OTA | Payload structure and trigger logic may differ between versions |
+
+The delta model (assert/retract/ignore) absorbs this variance naturally: the
+platform asserts what it can observe, ignores what it cannot, and retracts what
+has gone stale. A richly-connected Gen 4 scooter and a BLE-only Gen 1 scooter
+coexist in the same model; the Gen 1 simply has fewer asserted properties and
+longer gaps between updates.
+
+## Characters
+
+The tangible objects that interact in this world:
+
+| Character | Identity | Lifetime | What changes |
+|-----------|----------|----------|--------------|
+| **Modem** | IMEI (hardware), EID (eUICC) | Permanent — manufactured into the scooter | eSIM profile (ICCID, IMSI), IP session, firmware |
+| **Vehicle** | VIN (frame) | Permanent — stamped at manufacture | Which modem is installed, speed, location, ride status |
+| **Battery** | Serial number (BMS chip) | Permanent — printed on casing | Which vehicle it is installed in, charge level, cycle count |
+| **Operator classification** | IMEI + classifier source | Per classifier assertion | Which operator, confidence, classifier version |
+| **Model classification** | IMEI + classifier source | Per classifier assertion | Manufacturer, model designation, confidence |
+
+Note that the Modem and Vehicle are observed through independent channels
+(network layer vs application layer). For cellular-connected scooters, both
+characters are present and correlated. For phone-bridged scooters, the Vehicle
+may exist without a stable Modem anchor.

--- a/samples/micromobility/README.md
+++ b/samples/micromobility/README.md
@@ -504,6 +504,85 @@ timeout. Its stable properties (VIN, IMEI association) remain in the model
 indefinitely as historical record, until explicitly retracted by an
 administrative event.
 
+## Last Reported Values
+
+When the platform retracts a spot value (speed, location, IP) because its TTL
+expired, the value is gone from the live model. But for some properties, the
+stale value is still better than nothing.
+
+Consider a fleet dispatcher looking for scooter `WMX00042`, which went silent 40
+minutes ago. The live model shows no location (retracted after 15 minutes). But
+the *last reported* position, Rabin Square at 14:15, is still the best guess for
+where a technician should start looking. Similarly, the last reported battery
+level (84%) tells the dispatcher whether the scooter is worth retrieving or
+already depleted.
+
+Not every property benefits from this treatment. The table below names properties
+after the domain model, then describes what "last reported" means for each:
+
+| Property | Last reported useful? | Notes |
+|----------|---------------------|-------|
+| **GNSS fix** | Yes | The scooter's GPS position (lat, lng, altitude, precision). This is the primary geolocation source. A 40-minute-old fix is still the best starting point for a field technician searching for a silent scooter. |
+| **Serving cell** | Yes | The modem's serving cell (PLMN, tracking area, cell ID, signal strength). Provides a coarse geolocation estimate when GNSS is unavailable. But the last reported serving cell is not the only source of coarse position; see below. |
+| **Battery** | Moderate | The full BMS reading (serial, SoC, voltage, temperature, cycles). Helps prioritize which scooters need attention, but a stale level may be outdated by a swap or charging event the platform missed. |
+| **Speed** | No | Stale speed is misleading; you care about current or nothing. |
+| **InRide** | No | Stale ride status is unreliable. |
+| **IP** | No | Stale IP is likely reassigned to another device. |
+
+Note that the high-value properties (GNSS fix, serving cell, battery) are wide:
+they are structured objects with multiple fields, not scalars. "Last reported GNSS
+fix" means the entire `gnss` struct from the most recent telemetry report that
+had a valid fix, including its precision metadata (`hdop`, `sats`, `fix`).
+
+### Geolocation as a Derived View
+
+The properties above live in the domain model as-is (GNSS fix on the vehicle,
+serving cell on the modem). But fleet operations often want a single answer:
+"where is this scooter?" That answer, a *geolocation*, is derived from whichever
+source is available, in rough priority order:
+
+1. **GNSS fix** — highest precision (meters), from the scooter's GPS receiver.
+2. **Serving cell** — coarse (hundreds of meters to kilometers), from the modem's
+   last reported cell attachment or from the rider's phone during a BLE-bridged
+   ride.
+3. **Signaling triangulation** — moderate precision, derived from network
+   signaling associated with the IMSI (e.g., timing advance, neighboring cell
+   measurements).
+
+Each of these sources has different precision, freshness, and availability. The
+platform could maintain a composite "best available geolocation" that selects the
+best source, or leave the fusion to downstream consumers querying the individual
+properties. This is a design question for implementation.
+
+### How to Provide Last Reported Values
+
+Three approaches, each with different trade-offs:
+
+**Separate entity.** A dedicated entity type (e.g., a "last reported position"
+keyed on VIN) that is asserted alongside the spot value but is not subject to the
+same TTL. It carries its own timestamp ("as of when?") and is only overwritten by
+the next valid observation, never retracted by timeout. Clean separation, but
+doubles the number of entities for each property that needs it.
+
+**Additional fields on the same entity.** The Vehicle carries both `Location`
+(current, retractable) and `LastReportedLocation` (persistent until next
+observation). Simpler than a separate entity, but the two fields have different
+retraction semantics on the same struct, which complicates the delta model.
+Asserting a new location must update both fields; retracting by timeout must
+clear only the current one.
+
+**Analytics tier only.** The silver Parquet baseline already holds the latest
+snapshot per entity. "Last reported location" is a query: find the most recent
+snapshot where location was non-null. This requires no additional live entities
+and no Go struct changes. The trade-off is latency: the answer is only as fresh
+as the last silver rebuild, and consumers must query Parquet rather than subscribe
+to a live NATS stream.
+
+The right approach may vary by property. Geolocation, the highest-value case,
+could justify a live entity. Battery level, with moderate value and higher risk of being
+outdated, may be fine as an analytics query. The decision is deferred to
+implementation.
+
 ## Competing Knowledge
 
 Not everything the platform knows is certain. When two classifiers assert

--- a/samples/micromobility/README.md
+++ b/samples/micromobility/README.md
@@ -141,29 +141,75 @@ accommodates this through two mechanisms:
    retracts what has gone stale. A phone-bridged scooter with no telemetry
    between rides simply has its ephemeral properties retracted by timeout.
 
-## What the Network Sees
+## Instrumentation
 
-The observation platform sits at the cellular network layer. It sees data
-sessions, IP assignments, and DNS queries. It does not see app-level events (ride
-start, payment, user account) because those are encrypted end-to-end between the
-scooter's software and its operator's cloud.
+The observation platform does not receive data from a single source. Different
+instrumentation points provide different slices of information, each with its own
+data characteristics, refresh rate, and reliability.
 
-What the platform can observe directly:
+### Vendor Instrument
 
-- **Network layer** (from the cellular infrastructure): IMEI and IMSI when the
-  modem attaches, IP address when a session is established, serving cell identity
-  and signal strength.
-- **DNS queries** when the scooter's software resolves its operator's API domain
-  (e.g., `api.lime.com`, `device.bird.co`).
-- **Application layer** (from intercepted telemetry payloads): device ID, GPS
-  coordinates, speed, battery serial and state of charge, accelerometer status,
-  and the trigger that caused this particular report.
+Operators maintain registries that map physical scooter attributes to fleet
+identifiers. A vendor-specific instrument (an integration with the operator's
+provisioning system, or a tap into their asset management API) provides:
 
-The network layer and application layer are observed independently and correlated
-by the platform. For cellular-connected scooters, the correlation is
-straightforward: the application payload flows through the modem's IP session. For
-phone-bridged scooters, the application payload flows through the rider's phone,
-and the network-layer identity belongs to the phone.
+- **Frame identity**: VIN, hardware generation, manufacture date.
+- **Fleet correlation**: the operator-assigned fleet ID (the one encoded in the QR
+  code and used for manual unlock via the rider's app).
+- **Modem provisioning**: which IMEI is installed in which vehicle, eSIM profile
+  assignments.
+
+This data is stable. It changes on provisioning events (new scooter registered),
+modem replacements, or fleet reassignment (scooter sold between operators). It is
+the source of truth for correlating the physical vehicle (VIN) with the fleet
+identity and the modem (IMEI).
+
+### Network Tap
+
+A tap into the cellular network stack provides real-time access to signaling and
+DNS traffic flowing between scooters and their operator backends. Depending on the
+deployment, this may be a deep packet inspection appliance, a lawful intercept
+interface, or an API exposed by a network function. It provides:
+
+- **Signaling events**: modem attach/detach, IP session establishment, handovers,
+  serving cell identity.
+- **DNS queries**: domain name resolutions that reveal which operator's API the
+  scooter contacts (e.g., `api.lime.com`, `device.bird.co`).
+
+This is a real-time, high-frequency data source anchored on the IMEI. It provides
+the raw material for network-layer identity (IMEI, IMSI, IP) and for
+classification (DNS patterns, IMSI ranges).
+
+### Telemetry Feed
+
+Application-layer telemetry (the structured payloads described in
+[Telemetry Events](#telemetry-events)) does not necessarily come from the same
+network tap. While packet inspection can intercept telemetry in transit, a more
+common arrangement is for the platform to receive telemetry in batch from each
+fleet operator's backend: the operator collects reports from its scooters and
+periodically exports them.
+
+This means telemetry may arrive with different latency and completeness depending
+on the operator's export cadence and data-sharing agreement. Some operators stream
+near-real-time; others provide hourly or daily batches. The platform treats all
+telemetry the same way (as delta assertions keyed on device_id), regardless of how
+it was delivered.
+
+### What Each Instrument Contributes
+
+| Instrument | Data | Refresh | Identity anchor |
+|------------|------|---------|-----------------|
+| **Vendor instrument** | VIN, fleet ID, hardware generation, modem assignment | On provisioning events | VIN (vehicle frame) |
+| **Network tap** | IMEI, IMSI, IP, serving cell, DNS queries | On network events (real-time) | IMEI (modem) |
+| **Telemetry feed** | Device ID, GNSS, speed, battery, accelerometer, access point | Per report (real-time or batched) | device_id (fleet ID or VIN) |
+
+These instruments observe through independent channels. For cellular-connected
+scooters, the platform correlates them: the vendor instrument says "VIN
+`WMX00042` has IMEI `353456789012345`," the network tap sees that IMEI attach to
+the network, and the telemetry feed delivers application payloads keyed on the
+same device. For phone-bridged scooters, only the telemetry feed (relayed through
+the operator's backend) may be available; the vendor instrument provides the
+stable identity that the network layer cannot.
 
 ## Telemetry Events
 
@@ -195,17 +241,31 @@ fields below use standard abbreviations from IoT and vehicle telematics:
 | `battery.temp` | int | Cell temperature in °C |
 | `battery.cycles` | uint32 | Lifetime charge cycle count |
 | `odometer` | float64 | Cumulative trip distance in km |
-| `cell.mcc` | uint16 | Mobile Country Code of the serving cell |
-| `cell.mnc` | uint16 | Mobile Network Code |
-| `cell.cid` | uint32 | Cell ID |
-| `cell.rsrp` | int | Reference Signal Received Power in dBm |
+| `access` | object | Current point of attachment (see below) |
 | `accel.motion` | bool | Accelerometer motion detection flag |
 | `accel.tilt` | float64 | Tilt angle in degrees (0 = upright, 90 = on its side) |
 
-Not every field is present in every report. The scooter's software omits fields
-it cannot populate (e.g., `gnss.*` when there is no satellite fix) or fields
-irrelevant to the trigger (e.g., `cell.*` may be absent on phone-bridged
-scooters).
+The `access` field describes the scooter's current **point of attachment** to the
+wider network: the intermediate node through which data reaches the operator's
+backend. Its internal structure varies by connectivity type:
+
+- **Cellular** (`"cellular"`): the *serving cell*, the cell tower sector the modem
+  is camped on. Identified by PLMN, tracking area, and cell ID. Includes signal
+  quality (RSRP).
+- **Bluetooth** (`"bluetooth"`): the rider's phone acting as a relay. Identified
+  by a peer identifier. Includes signal quality (RSSI).
+- **Station** (`"station"`): a fixed infrastructure access point, typically WiFi
+  at a docking station. Identified by the AP's address. Includes signal quality
+  (RSSI).
+
+The scooter's software includes the current access point in each telemetry report
+when available. When the point of attachment changes (cell handover, new phone
+pairs, docking station connects) or its properties update meaningfully, a
+dedicated trigger fires (see [Triggers](#triggers)).
+
+Not every field is present in every report. The scooter's software omits fields it
+cannot populate (e.g., `gnss.*` when there is no satellite fix, `access` on
+scooters with no active connectivity metadata).
 
 The `device_id` is the application-layer identity of the scooter. It is
 independent of the IMEI: the IMEI belongs to the modem at the network layer,
@@ -239,7 +299,8 @@ the reporting frequency and the `accel.motion` flag.
 | `impact` | Accelerometer spike exceeds impact threshold (fall or collision) |
 | `battery_swap` | BMS reports a different battery serial after power cycle |
 | `low_battery` | State of charge drops below configured threshold |
-| `cell_change` | Serving cell changes (handover between towers) |
+| `access_change` | Point of attachment changes (cell handover, new phone, dock connect) |
+| `access_update` | Same point of attachment, signal quality or properties refreshed |
 | `gnss_fix` | GNSS acquires a fix after a period with no fix |
 | `power_on` | Scooter boots after battery insertion or deep sleep wake |
 
@@ -348,14 +409,14 @@ assertions, all keyed on the same IMEI.
 ### Mid-Ride: Cell Handover
 
 The rider crosses into a different cell sector. The network hands over the
-session. The scooter's software detects the cell change:
+session. The scooter's software detects the change in point of attachment:
 
 ```
-{device_id: "WMX00042", ts: "08:22:17Z", seq: 81244, trigger: "cell_change",
+{device_id: "WMX00042", ts: "08:22:17Z", seq: 81244, trigger: "access_change",
  gnss: {lat: 32.0812, lng: 34.7801, fix: "3d", hdop: 0.8, sats: 12},
  speed: 16.4, heading: 12,
  battery: {id: "BAT-2187", soc: 0.91, ..},
- cell: {mcc: 425, mnc: 01, cid: 52417, rsrp: -78},
+ access: {type: "cellular", mcc: 425, mnc: 01, tac: 12401, cid: 52417, rsrp: -78},
  accel: {motion: true, ..}}
 ```
 
@@ -401,7 +462,7 @@ weakens. Eventually, the scooter's software cannot send at all:
 {device_id: "WMX00042", ts: "14:15:42Z", seq: 81793, trigger: "periodic",
  gnss: {fix: "none"},
  battery: {id: "BAT-2187", soc: 0.84, ..},
- cell: {mcc: 425, mnc: 01, cid: 52418, rsrp: -112},
+ access: {type: "cellular", mcc: 425, mnc: 01, tac: 12401, cid: 52418, rsrp: -112},
  accel: {motion: false, tilt: 2.1}}
 
 ... then silence.

--- a/samples/micromobility/README.md
+++ b/samples/micromobility/README.md
@@ -255,12 +255,13 @@ wider network: the interface through which data reaches the operator's backend.
 Its internal structure varies by connectivity type:
 
 - **Cellular** (`"cellular"`): the built-in modem. The scooter's software can
-  always read the modem's IP address from the OS network stack. Modem identifiers
-  (IMEI, EID, ICCID, IMSI) may be available if the firmware queries the modem's
-  AT command interface; many embedded platforms expose this unprivileged, but it is
-  not guaranteed. The software has no access to radio-level data (serving cell,
-  signal quality, neighbor cells); that information exists only on the network
-  side.
+  always read the modem's IP address from the OS network stack. The IMEI and IMSI
+  may be available if the firmware queries the modem via standard AT commands
+  (`AT+CGSN`, `AT+CIMI`); many embedded platforms expose this unprivileged, but
+  it is not guaranteed. eSIM-level identifiers (EID, ICCID) are generally not
+  accessible through the AT interface. The software has no access to radio-level
+  data (serving cell, signal quality, neighbor cells); that information exists
+  only on the network side.
 - **Bluetooth** (`"bluetooth"`): the rider's phone acting as a relay. Identified
   by the phone's BLE device name (the Local Name advertised during pairing).
 - **Station** (`"station"`): a fixed infrastructure access point, typically WiFi

--- a/samples/micromobility/README.md
+++ b/samples/micromobility/README.md
@@ -639,6 +639,33 @@ shared across brands. Classifiers are imperfect and versioned: today's
 accuracy characteristics. The domain model holds all perspectives simultaneously
 rather than forcing premature resolution.
 
+## Overlapping Observations
+
+A digital twin system observes the same physical entities from multiple
+independent vantage points. The scooter's IP address appears in two places:
+the OS network stack (telemetry) and the network tap (signaling). The modem's
+IMEI is reported by AT commands in the telemetry payload and observed directly
+by the network tap. The battery serial comes from the BMS chip via telemetry
+and from the operator's asset database via the vendor instrument.
+
+This overlap is not redundant; it is the system's primary source of insight.
+When independent observations agree, the agreement is a positive reinforcement
+signal: the system's model of the world is consistent. When they disagree, the
+discrepancy is equally valuable. An IP mismatch between telemetry and the
+network tap may indicate a stale session, a NAT traversal, or a
+miscorrelation. A battery serial that the telemetry reports but the vendor
+instrument does not recognize may indicate an unregistered replacement part.
+
+Higher-order mechanisms built on top of the digital twin (anomaly detection,
+compliance auditing, fleet analytics) consume these signals. The twin itself
+does not resolve them; it holds all observations faithfully and lets downstream
+consumers decide what the disagreement means. This is why the domain model
+maintains separate entities for each observation perspective (Modem from the
+network tap, Vehicle from telemetry, classifications from automated
+classifiers) rather than merging them into a single canonical record. The
+separation preserves the provenance that makes corroboration and conflict
+detection possible.
+
 ## Variance
 
 The scooter domain has many axes of variation, and the platform must handle them

--- a/samples/micromobility/README.md
+++ b/samples/micromobility/README.md
@@ -790,3 +790,30 @@ Note that the Modem and Vehicle are observed through independent channels
 (network layer vs application layer). For cellular-connected scooters, both
 characters are present and correlated. For phone-bridged scooters, the Vehicle
 may exist without a stable Modem anchor.
+
+## Appendix: Stakeholders
+
+A _stakeholder_ here follows the INCOSE sense: any party with an interest,
+claim, or concern that affects, or is affected by, the observation platform.
+Stakeholders sit outside the platform's data boundary, distinct from the
+entities the platform models (see [Characters](#characters)). The table below
+names the parties whose decisions, expectations, or constraints shape the domain
+model and the observability concerns it must satisfy.
+
+| Stakeholder                       | Role in the world                                                                                                     | Stake in the platform                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **Platform consumer**             | Analytics and operations teams that query the digital twin (anomaly detection, fleet health, compliance reporting)    | Accurate, fresh, well-attributed observations across the full fleet, with provenance preserved across instruments      |
+| **Platform operator**             | The team running the observation platform itself                                                                      | System reliability; clean ingestion from each instrument; low-friction onboarding of new operators and new classifiers |
+| **Fleet operator**                | Companies operating the scooters (Lime, Bird, Dot, others); supply provisioning data and (in some setups) telemetry   | A view of their fleet that is consistent with their own asset registry; classifications that do not misattribute units |
+| **Mobile network operator**       | Cellular carrier providing connectivity; hosts or grants access to the network tap                                    | Network capacity planning, IoT subscription accounting, integrity of signaling-derived observations                    |
+| **eSIM management provider**      | Issues and remotely provisions eSIM profiles onto eUICCs                                                              | Profile lifecycle visibility (ICCID/IMSI assignment events) so platform consumers can attribute observed identity flux |
+| **Rider**                         | End-user who unlocks and rides scooters                                                                               | Service availability; minimal retention of personal-location data beyond what safety and dispute resolution require    |
+| **Field technician**              | Operator-employed workers who swap batteries, relocate scooters, and perform maintenance ("juicers", "chargers")      | Fresh last-known-good location and battery state to plan retrieval routes                                              |
+| **City / municipal regulator**    | Local authority setting deployment, parking, and geofencing rules                                                     | Verifiable compliance reports; aggregate fleet behavior summaries; auditability                                        |
+| **Hardware manufacturer**         | Builders of scooters, modems, and firmware (e.g. Segway, Quectel, Sierra Wireless)                                    | Classifier accuracy on hardware identity; visibility into firmware-version-specific behavior surfaced by the platform  |
+| **Data protection authority**     | Regulator enforcing privacy law over geolocation and subscriber data                                                  | Provenance, retention, and minimization controls over personal data flowing through the platform                       |
+| **Standards bodies (3GPP, GSMA)** | Define the protocols and identifiers (IMEI, IMSI, AT command suite, eSIM management) the platform observes and parses | Faithful interpretation of standardized identifiers and procedures; the platform must not silently drift from the spec |
+
+Stakeholders are not modeled as entities in the digital twin; their concerns
+inform what gets modeled, what gets retained, and which cross-instrument
+correlations the platform invests in.

--- a/samples/micromobility/README.md
+++ b/samples/micromobility/README.md
@@ -1,9 +1,9 @@
 # Shared Electric Scooters
 
 This sample domain models shared electric scooters (Lime, Bird, Dot and similar
-operators) as seen from a cellular network observation platform. The platform does
-not have access to any operator's fleet management system. Everything it knows
-about the scooters, it learns from the network.
+operators) as seen from a cellular network observation platform. The platform
+does not have access to any operator's fleet management system. Everything it
+knows about the scooters, it learns from the network.
 
 ## The World
 
@@ -29,10 +29,10 @@ brain. It provides an IP interface to the scooter's software much like an
 Ethernet adapter on a server.
 
 Scooters carry a VIN stamped on the frame and a QR code for riders to scan. From
-the operator's perspective, these are the primary identifiers. From the network's
-perspective, the scooter itself is invisible; only the network interface's
-identifiers (IMEI, IMSI, IP for cellular; the phone's identifiers for
-Bluetooth-bridged scooters) are visible.
+the operator's perspective, these are the primary identifiers. From the
+network's perspective, the scooter itself is invisible; only the network
+interface's identifiers (IMEI, IMSI, IP for cellular; the phone's identifiers
+for Bluetooth-bridged scooters) are visible.
 
 ### Modems and eSIMs
 
@@ -53,59 +53,60 @@ ephemeral, reassigned on every new data session.
 
 Scooters run on swappable lithium-ion battery packs. Each pack has a serial
 number printed on its casing and a small BMS (battery management system) chip
-that reports charge level and cycle count through the scooter's telemetry payload.
-Field technicians swap batteries in the street: they pull the depleted pack,
-insert a fresh one, and move on. A single battery may pass through dozens of
-scooters over its lifetime.
+that reports charge level and cycle count through the scooter's telemetry
+payload. Field technicians swap batteries in the street: they pull the depleted
+pack, insert a fresh one, and move on. A single battery may pass through dozens
+of scooters over its lifetime.
 
 ### Riders and Rides
 
-A rider unlocks a scooter through the operator's app, rides to a destination, and
-parks it. From the network side, a ride looks like a burst of frequent telemetry
-beacons with non-zero speed and changing GPS coordinates. The ride itself is a
-business concept managed by the operator's backend; the network never sees a
-"ride started" or "ride ended" event directly. It can only infer ride activity
-from the telemetry pattern.
+A rider unlocks a scooter through the operator's app, rides to a destination,
+and parks it. From the network side, a ride looks like a burst of frequent
+telemetry beacons with non-zero speed and changing GPS coordinates. The ride
+itself is a business concept managed by the operator's backend; the network
+never sees a "ride started" or "ride ended" event directly. It can only infer
+ride activity from the telemetry pattern.
 
 ### Field Technicians
 
-Operators employ field technicians (sometimes called "juicers" or "chargers") who
-drive vans through the city collecting scooters with low batteries, swapping
-packs, relocating scooters to high-demand areas, and performing maintenance. From
-the network's perspective, a battery swap manifests as a sudden change in the
-battery serial number reported in the telemetry payload. A relocation looks like a
-GPS jump while the scooter is not in a ride.
+Operators employ field technicians (sometimes called "juicers" or "chargers")
+who drive vans through the city collecting scooters with low batteries, swapping
+packs, relocating scooters to high-demand areas, and performing maintenance.
+From the network's perspective, a battery swap manifests as a sudden change in
+the battery serial number reported in the telemetry payload. A relocation looks
+like a GPS jump while the scooter is not in a ride.
 
 ## How Scooters Connect
 
-Not all scooters connect the same way. The connectivity model varies by operator,
-hardware generation, and cost trade-offs. This variance directly affects what the
-observation platform can see and how reliably it can track each scooter.
+Not all scooters connect the same way. The connectivity model varies by
+operator, hardware generation, and cost trade-offs. This variance directly
+affects what the observation platform can see and how reliably it can track each
+scooter.
 
 ### Cellular (always-on modem)
 
-The richest observability scenario. The scooter has a built-in cellular modem with
-an eSIM. It maintains a persistent data session even when idle: the modem is
-always attached to the network, the IP address is allocated, and the scooter's
-software sends periodic heartbeats regardless of ride activity. The platform sees
-the modem's IMEI and IMSI at the network layer and correlates them with the
-application-layer telemetry flowing through the session.
+The richest observability scenario. The scooter has a built-in cellular modem
+with an eSIM. It maintains a persistent data session even when idle: the modem
+is always attached to the network, the IP address is allocated, and the
+scooter's software sends periodic heartbeats regardless of ride activity. The
+platform sees the modem's IMEI and IMSI at the network layer and correlates them
+with the application-layer telemetry flowing through the session.
 
 This is the primary scenario explored in this domain model.
 
 ### Phone-bridged (Bluetooth relay)
 
-Some operators (or earlier hardware generations) save the cost of a cellular modem
-by having the scooter communicate through the rider's phone. The scooter connects
-to the phone via Bluetooth Low Energy; the phone relays telemetry to the
-operator's backend over its own cellular connection.
+Some operators (or earlier hardware generations) save the cost of a cellular
+modem by having the scooter communicate through the rider's phone. The scooter
+connects to the phone via Bluetooth Low Energy; the phone relays telemetry to
+the operator's backend over its own cellular connection.
 
-From the platform's perspective, the scooter is invisible between rides. During a
-ride, the platform sees the *phone's* IMEI, IMSI, and IP, not the scooter's. The
-application payload still contains the scooter's device ID and sensor readings,
-but the network-layer anchor belongs to the phone and changes with every rider.
-The platform can extract telemetry but cannot maintain a persistent identity for
-the scooter across rides.
+From the platform's perspective, the scooter is invisible between rides. During
+a ride, the platform sees the _phone's_ IMEI, IMSI, and IP, not the scooter's.
+The application payload still contains the scooter's device ID and sensor
+readings, but the network-layer anchor belongs to the phone and changes with
+every rider. The platform can extract telemetry but cannot maintain a persistent
+identity for the scooter across rides.
 
 ### Hybrid
 
@@ -144,8 +145,8 @@ accommodates this through two mechanisms:
 ## Instrumentation
 
 The observation platform does not receive data from a single source. Different
-instrumentation points provide different slices of information, each with its own
-data characteristics, refresh rate, and reliability.
+instrumentation points provide different slices of information, each with its
+own data characteristics, refresh rate, and reliability.
 
 ### Vendor Instrument
 
@@ -154,30 +155,30 @@ identifiers. A vendor-specific instrument (an integration with the operator's
 provisioning system, or a tap into their asset management API) provides:
 
 - **Frame identity**: VIN, hardware generation, manufacture date.
-- **Fleet correlation**: the operator-assigned fleet ID (the one encoded in the QR
-  code and used for manual unlock via the rider's app).
+- **Fleet correlation**: the operator-assigned fleet ID (the one encoded in the
+  QR code and used for manual unlock via the rider's app).
 - **Modem provisioning**: which IMEI is installed in which vehicle, eSIM profile
   assignments.
 
 This data is stable. It changes on provisioning events (new scooter registered),
-modem replacements, or fleet reassignment (scooter sold between operators). It is
-the source of truth for correlating the physical vehicle (VIN) with the fleet
+modem replacements, or fleet reassignment (scooter sold between operators). It
+is the source of truth for correlating the physical vehicle (VIN) with the fleet
 identity and the modem (IMEI).
 
 ### Network Tap
 
 A tap into the cellular network stack provides real-time access to signaling and
-DNS traffic flowing between scooters and their operator backends. Depending on the
-deployment, this may be a deep packet inspection appliance, a lawful intercept
-interface, or an API exposed by a network function. It provides:
+DNS traffic flowing between scooters and their operator backends. Depending on
+the deployment, this may be a deep packet inspection appliance, a lawful
+intercept interface, or an API exposed by a network function. It provides:
 
-- **Signaling events**: modem attach/detach, IP session establishment, handovers,
-  serving cell identity.
+- **Signaling events**: modem attach/detach, IP session establishment,
+  handovers, serving cell identity.
 - **DNS queries**: domain name resolutions that reveal which operator's API the
   scooter contacts (e.g., `api.lime.com`, `device.bird.co`).
 
-This is a real-time, high-frequency data source anchored on the IMEI. It provides
-the raw material for network-layer identity (IMEI, IMSI, IP) and for
+This is a real-time, high-frequency data source anchored on the IMEI. It
+provides the raw material for network-layer identity (IMEI, IMSI, IP) and for
 classification (DNS patterns, IMSI ranges).
 
 ### Telemetry Feed
@@ -189,19 +190,19 @@ common arrangement is for the platform to receive telemetry in batch from each
 fleet operator's backend: the operator collects reports from its scooters and
 periodically exports them.
 
-This means telemetry may arrive with different latency and completeness depending
-on the operator's export cadence and data-sharing agreement. Some operators stream
-near-real-time; others provide hourly or daily batches. The platform treats all
-telemetry the same way (as delta assertions keyed on device_id), regardless of how
-it was delivered.
+This means telemetry may arrive with different latency and completeness
+depending on the operator's export cadence and data-sharing agreement. Some
+operators stream near-real-time; others provide hourly or daily batches. The
+platform treats all telemetry the same way (as delta assertions keyed on
+device_id), regardless of how it was delivered.
 
 ### What Each Instrument Contributes
 
-| Instrument | Data | Refresh | Identity anchor |
-|------------|------|---------|-----------------|
-| **Vendor instrument** | VIN, fleet ID, hardware generation, modem assignment | On provisioning events | VIN (vehicle frame) |
-| **Network tap** | IMEI, IMSI, IP, serving cell, signal quality, DNS queries | On network events (real-time) | IMEI (modem) |
-| **Telemetry feed** | Device ID, GNSS, speed, battery, accelerometer, point of attachment (IP, modem IDs if available, BLE device name, dock ID) | Per report (real-time or batched) | device_id (fleet ID or VIN) |
+| Instrument            | Data                                                                                                                       | Refresh                           | Identity anchor             |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | --------------------------- |
+| **Vendor instrument** | VIN, fleet ID, hardware generation, modem assignment                                                                       | On provisioning events            | VIN (vehicle frame)         |
+| **Network tap**       | IMEI, IMSI, IP, serving cell, signal quality, DNS queries                                                                  | On network events (real-time)     | IMEI (modem)                |
+| **Telemetry feed**    | Device ID, GNSS, speed, battery, accelerometer, point of attachment (IP, modem IDs if available, BLE device name, dock ID) | Per report (real-time or batched) | device_id (fleet ID or VIN) |
 
 These instruments observe through independent channels. The IP address is the
 primary bridge between them: the scooter's software always knows its IP (the OS
@@ -209,8 +210,8 @@ provides it), the network tap knows which IMEI holds which IP session, and the
 vendor instrument maps the IMEI to a VIN. For cellular-connected scooters, the
 full correlation chain is: VIN → IMEI (vendor), IMEI → IP (network tap),
 telemetry source IP → device_id (telemetry feed). If the scooter's firmware also
-queries the modem's IMEI via AT commands, the telemetry `access` field provides a
-direct confirmation, but the IP-based correlation does not depend on it.
+queries the modem's IMEI via AT commands, the telemetry `access` field provides
+a direct confirmation, but the IP-based correlation does not depend on it.
 
 For phone-bridged scooters, only the telemetry feed (relayed through the
 operator's backend) may be available; the vendor instrument provides the stable
@@ -224,78 +225,79 @@ generation, but the general patterns are consistent across the industry.
 
 ### Payload Structure
 
-Each telemetry report carries a common envelope and a set of sensor readings. The
-fields below use standard abbreviations from IoT and vehicle telematics:
+Each telemetry report carries a common envelope and a set of sensor readings.
+The fields below use standard abbreviations from IoT and vehicle telematics:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `device_id` | string | Scooter identity (VIN or operator-assigned fleet ID) |
-| `ts` | ISO 8601 | Timestamp at the scooter's clock |
-| `seq` | uint32 | Monotonic sequence number; gaps reveal lost reports |
-| `trigger` | string | Why this report was sent (see [Triggers](#triggers)) |
-| `gnss.lat`, `gnss.lng` | float64 | WGS 84 coordinates |
-| `gnss.alt` | float64 | Altitude in meters above sea level |
-| `gnss.hdop` | float64 | Horizontal dilution of precision (lower is better) |
-| `gnss.sats` | uint8 | Satellites used in the fix |
-| `gnss.fix` | string | Fix quality: `"none"`, `"2d"`, `"3d"` |
-| `speed` | float64 | Ground speed in km/h (GNSS-derived) |
-| `heading` | float64 | Course over ground in degrees, 0–360 |
-| `battery.id` | string | BMS-reported serial number of the installed pack |
-| `battery.soc` | float64 | State of charge, 0.0–1.0 |
-| `battery.voltage` | float64 | Pack voltage in volts |
-| `battery.temp` | int | Cell temperature in °C |
-| `battery.cycles` | uint32 | Lifetime charge cycle count |
-| `odometer` | float64 | Cumulative trip distance in km |
-| `access` | object | Current point of attachment (see below) |
-| `accel.motion` | bool | Accelerometer motion detection flag |
-| `accel.tilt` | float64 | Tilt angle in degrees (0 = upright, 90 = on its side) |
+| Field                  | Type     | Description                                           |
+| ---------------------- | -------- | ----------------------------------------------------- |
+| `device_id`            | string   | Scooter identity (VIN or operator-assigned fleet ID)  |
+| `ts`                   | ISO 8601 | Timestamp at the scooter's clock                      |
+| `seq`                  | uint32   | Monotonic sequence number; gaps reveal lost reports   |
+| `trigger`              | string   | Why this report was sent (see [Triggers](#triggers))  |
+| `gnss.lat`, `gnss.lng` | float64  | WGS 84 coordinates                                    |
+| `gnss.alt`             | float64  | Altitude in meters above sea level                    |
+| `gnss.hdop`            | float64  | Horizontal dilution of precision (lower is better)    |
+| `gnss.sats`            | uint8    | Satellites used in the fix                            |
+| `gnss.fix`             | string   | Fix quality: `"none"`, `"2d"`, `"3d"`                 |
+| `speed`                | float64  | Ground speed in km/h (GNSS-derived)                   |
+| `heading`              | float64  | Course over ground in degrees, 0–360                  |
+| `battery.id`           | string   | BMS-reported serial number of the installed pack      |
+| `battery.soc`          | float64  | State of charge, 0.0–1.0                              |
+| `battery.voltage`      | float64  | Pack voltage in volts                                 |
+| `battery.temp`         | int      | Cell temperature in °C                                |
+| `battery.cycles`       | uint32   | Lifetime charge cycle count                           |
+| `odometer`             | float64  | Cumulative trip distance in km                        |
+| `access`               | object   | Current point of attachment (see below)               |
+| `accel.motion`         | bool     | Accelerometer motion detection flag                   |
+| `accel.tilt`           | float64  | Tilt angle in degrees (0 = upright, 90 = on its side) |
 
-The `access` field describes the scooter's current **point of attachment** to the
-wider network: the interface through which data reaches the operator's backend.
-Its internal structure varies by connectivity type:
+The `access` field describes the scooter's current **point of attachment** to
+the wider network: the interface through which data reaches the operator's
+backend. Its internal structure varies by connectivity type:
 
 - **Cellular** (`"cellular"`): the built-in modem. The scooter's software can
   always read the modem's IP address from the OS network stack. Beyond the IP,
   3GPP TS 27.007 standardizes a set of AT commands that the firmware can use to
   query the modem, though not every modem or firmware implements the full spec:
 
-  | AT Command | Data | Notes |
-  |------------|------|-------|
-  | `AT+CGSN` | IMEI | Modem hardware identity |
-  | `AT+CIMI` | IMSI | Subscriber identity from the active profile |
-  | `AT+COPS` | Registered operator (PLMN) | Operator name or MCC-MNC |
-  | `AT+CREG` / `AT+CEREG` | Registration status | Whether the modem is registered, roaming, or searching |
-  | `AT+CGDCONT` | APN / PDP context | Data session configuration |
-  | `AT+CGATT` | Attach status | Whether the modem is attached to packet services |
+  | AT Command                      | Data                                | Notes                                                    |
+  | ------------------------------- | ----------------------------------- | -------------------------------------------------------- |
+  | `AT+CGSN`                       | IMEI                                | Modem hardware identity                                  |
+  | `AT+CIMI`                       | IMSI                                | Subscriber identity from the active profile              |
+  | `AT+COPS`                       | Registered operator (PLMN)          | Operator name or MCC-MNC                                 |
+  | `AT+CREG` / `AT+CEREG`          | Registration status                 | Whether the modem is registered, roaming, or searching   |
+  | `AT+CGDCONT`                    | APN / PDP context                   | Data session configuration                               |
+  | `AT+CGATT`                      | Attach status                       | Whether the modem is attached to packet services         |
   | `AT+CGMI`, `AT+CGMM`, `AT+CGMR` | Modem manufacturer, model, firmware | Hardware and software identification of the modem itself |
 
   All of these are best-effort from the telemetry perspective: the firmware may
   not query them, the modem may not implement them fully, and the values may lag
-  behind the network's own view of the same session. eSIM-level identifiers (EID,
-  ICCID) are generally not accessible through the standard AT interface. Signal
-  quality metrics (RSRP, RSRQ), neighbor cell measurements, and handover events
-  are not available through standard commands; that information exists only on the
-  network side.
+  behind the network's own view of the same session. eSIM-level identifiers
+  (EID, ICCID) are generally not accessible through the standard AT interface.
+  Signal quality metrics (RSRP, RSRQ), neighbor cell measurements, and handover
+  events are not available through standard commands; that information exists
+  only on the network side.
 - **Bluetooth** (`"bluetooth"`): the rider's phone acting as a relay. Identified
   by the phone's BLE device name (the Local Name advertised during pairing).
 - **Station** (`"station"`): a fixed infrastructure access point, typically WiFi
   at a docking station. Identified by the station's network identifier (BSSID or
   operator-assigned dock ID).
 
-The scooter's software includes the current access point in each telemetry report
-when available. When the point of attachment changes in a way the software can
-observe (IP reassignment after a cellular reconnect, new phone pairs, docking
-station connects), a dedicated trigger fires (see [Triggers](#triggers)).
+The scooter's software includes the current access point in each telemetry
+report when available. When the point of attachment changes in a way the
+software can observe (IP reassignment after a cellular reconnect, new phone
+pairs, docking station connects), a dedicated trigger fires (see
+[Triggers](#triggers)).
 
-Not every field is present in every report. The scooter's software omits fields it
-cannot populate (e.g., `gnss.*` when there is no satellite fix, `access` on
+Not every field is present in every report. The scooter's software omits fields
+it cannot populate (e.g., `gnss.*` when there is no satellite fix, `access` on
 scooters with no active connectivity metadata).
 
 The `device_id` is the application-layer identity of the scooter. It is
 independent of the IMEI: the IMEI belongs to the modem at the network layer,
-while the `device_id` belongs to the scooter's software at the application layer.
-The platform correlates the two by observing which `device_id` payloads flow
-through which IMEI's IP session.
+while the `device_id` belongs to the scooter's software at the application
+layer. The platform correlates the two by observing which `device_id` payloads
+flow through which IMEI's IP session.
 
 ### Triggers
 
@@ -305,47 +307,49 @@ by the scooter's software):
 
 **Periodic:**
 
-| Trigger | Cadence | Condition |
-|---------|---------|-----------|
-| `periodic` | 60–120 s | Scooter is idle (no motion detected) |
-| `periodic` | 2–5 s | Scooter is in motion (ride in progress) |
+| Trigger    | Cadence  | Condition                               |
+| ---------- | -------- | --------------------------------------- |
+| `periodic` | 60–120 s | Scooter is idle (no motion detected)    |
+| `periodic` | 2–5 s    | Scooter is in motion (ride in progress) |
 
-The cadence is governed by the scooter's firmware. The same trigger value
-covers both idle and ride modes; the platform infers the scooter's state from
-the reporting frequency and the `accel.motion` flag.
+The cadence is governed by the scooter's firmware. The same trigger value covers
+both idle and ride modes; the platform infers the scooter's state from the
+reporting frequency and the `accel.motion` flag.
 
 **Edge-triggered:**
 
-| Trigger | Fired when |
-|---------|------------|
-| `motion_start` | Accelerometer transitions from stationary to moving |
-| `motion_stop` | Accelerometer transitions from moving to stationary |
-| `impact` | Accelerometer spike exceeds impact threshold (fall or collision) |
-| `battery_swap` | BMS reports a different battery serial after power cycle |
-| `low_battery` | State of charge drops below configured threshold |
+| Trigger         | Fired when                                                                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `motion_start`  | Accelerometer transitions from stationary to moving                                                                                        |
+| `motion_stop`   | Accelerometer transitions from moving to stationary                                                                                        |
+| `impact`        | Accelerometer spike exceeds impact threshold (fall or collision)                                                                           |
+| `battery_swap`  | BMS reports a different battery serial after power cycle                                                                                   |
+| `low_battery`   | State of charge drops below configured threshold                                                                                           |
 | `access_update` | Connectivity change that requires immediate attention (new IP after cellular reconnect, new phone pairs via BLE, docking station connects) |
-| `gnss_fix` | GNSS acquires a fix after a period with no fix |
-| `power_on` | Scooter boots after battery insertion or deep sleep wake |
+| `gnss_fix`      | GNSS acquires a fix after a period with no fix                                                                                             |
+| `power_on`      | Scooter boots after battery insertion or deep sleep wake                                                                                   |
 
-Edge-triggered reports are sent immediately, independently of the periodic timer.
-A burst of events can occur in quick succession (e.g., `power_on` followed by
-`battery_swap` followed by `gnss_fix` within seconds of a battery replacement).
+Edge-triggered reports are sent immediately, independently of the periodic
+timer. A burst of events can occur in quick succession (e.g., `power_on`
+followed by `battery_swap` followed by `gnss_fix` within seconds of a battery
+replacement).
 
 ### Reporting Cadence Over Time
 
 ```
-          power_on  motion_start       periodic (ride)         motion_stop
-              │         │          ┌──────────┬──────────┐         │
-  ──idle──────┼─────────┼──ride────┼──ride────┼──ride────┼─────────┼──idle─────
-  60s    60s  ▼    60s  ▼  3s  3s  ▼  3s  3s  ▼  3s  3s  ▼   3s   ▼  60s   60s
-  ·      ·    ·    ·    ·  · · · · ·  · · · · ·  · · · · ·   · ·  ·  ·     ·
+        power_on  motion_start       periodic (ride)         motion_stop
+            │         │          ┌──────────┬──────────┐         │
+──idle──────┼─────────┼──ride────┼──ride────┼──ride────┼─────────┼──idle─────
+60s    60s  ▼    60s  ▼  3s  3s  ▼  3s  3s  ▼  3s  3s  ▼   3s   ▼  60s   60s
+·      ·    ·    ·    ·  · · · · ·  · · · · ·  · · · · ·   · ·  ·  ·     ·
 ```
 
 ## A Scooter's Day
 
 The following traces one cellular-connected scooter through a full day. This is
-the richest observability scenario; phone-bridged scooters would produce a sparser
-sequence (telemetry only during rides, no persistent modem identity, longer gaps).
+the richest observability scenario; phone-bridged scooters would produce a
+sparser sequence (telemetry only during rides, no persistent modem identity,
+longer gaps).
 
 ### Early Morning
 
@@ -381,10 +385,10 @@ comes back up. Three edge-triggered events fire in rapid succession:
  accel: {motion: false, tilt: 2.4}}
 ```
 
-Note: the `power_on` event has no GNSS data because the receiver has not acquired
-a fix yet. The `battery_swap` event fires once the scooter's software detects the
-new battery serial. The `gnss_fix` event follows a few seconds later when
-satellites are reacquired.
+Note: the `power_on` event has no GNSS data because the receiver has not
+acquired a fix yet. The `battery_swap` event fires once the scooter's software
+detects the new battery serial. The `gnss_fix` event follows a few seconds later
+when satellites are reacquired.
 
 In the platform's model, `BAT-2187` is now associated with `WMX00042`, and
 `BAT-1042` has no vehicle association until it appears in another scooter.
@@ -422,12 +426,12 @@ The platform asserts Speed and Location on each beacon and detects the sustained
 movement pattern, setting InRide to true.
 
 Meanwhile, at the network layer, the scooter's modem resolves `api.lime.com`. A
-DNS-based classifier asserts that IMEI `353456789012345` is operated by Lime with
-0.92 confidence. An IMSI-range analyzer recognizes the IMSI prefix `42501...` as
-a Lime-contracted SIM plan and asserts the same operator at 0.71 confidence. A
-payload-structure classifier recognizes the telemetry encoding as Segway Max G30
-firmware and asserts a model classification. Three classifiers, three independent
-assertions, all keyed on the same IMEI.
+DNS-based classifier asserts that IMEI `353456789012345` is operated by Lime
+with 0.92 confidence. An IMSI-range analyzer recognizes the IMSI prefix
+`42501...` as a Lime-contracted SIM plan and asserts the same operator at 0.71
+confidence. A payload-structure classifier recognizes the telemetry encoding as
+Segway Max G30 firmware and asserts a model classification. Three classifiers,
+three independent assertions, all keyed on the same IMEI.
 
 ### Mid-Ride: IP Reassignment
 
@@ -445,11 +449,11 @@ the IP change on its network interface and fires an access update:
 ```
 
 The scooter knows its new IP (the OS provides it) and its IMEI (queried via AT
-commands on this hardware). It does not know *why* the IP changed: cell handover,
-session timeout, or carrier-side reassignment are all invisible at the
+commands on this hardware). It does not know _why_ the IP changed: cell
+handover, session timeout, or carrier-side reassignment are all invisible at the
 application layer. At the network layer, the platform's tap sees the same IMEI
-re-attach with the new IP; it correlates the telemetry flowing from `100.72.31.88`
-with the existing Modem entity.
+re-attach with the new IP; it correlates the telemetry flowing from
+`100.72.31.88` with the existing Modem entity.
 
 ### Ride Ends
 
@@ -494,23 +498,23 @@ report before silence:
 ... then silence.
 ```
 
-The scooter's software has no visibility into the cellular signal degradation that
-causes the silence. It simply cannot send. The signal loss is observable from the
-network side: the platform's tap sees the IMSI's radio conditions deteriorate
-(weak RSRP, handover failures) and eventually the session drop. This
+The scooter's software has no visibility into the cellular signal degradation
+that causes the silence. It simply cannot send. The signal loss is observable
+from the network side: the platform's tap sees the IMSI's radio conditions
+deteriorate (weak RSRP, handover failures) and eventually the session drop. This
 supplementary instrumentation, correlated with the modem's IMSI, provides the
 radio context that the scooter's own telemetry cannot.
 
 After the configured telemetry TTL expires (say, 15 minutes with no beacon), the
 platform retracts Speed, Location, and InRide. The scooter still exists in the
-model (VIN, IMEI association, battery serial are stable facts), but its ephemeral
-properties are gone. The platform knows the scooter exists; it does not know where
-it is or what it is doing.
+model (VIN, IMEI association, battery serial are stable facts), but its
+ephemeral properties are gone. The platform knows the scooter exists; it does
+not know where it is or what it is doing.
 
-Note the last report: the GNSS fix was `"none"` but the battery and accelerometer
-data were still valid. The scooter's software sent what it could. The platform
-asserted the battery level and retracted the location (no fix means no
-coordinates). Partial data is normal.
+Note the last report: the GNSS fix was `"none"` but the battery and
+accelerometer data were still valid. The scooter's software sent what it could.
+The platform asserted the battery level and retracted the location (no fix means
+no coordinates). Partial data is normal.
 
 If the IP session also times out on the network side, the platform retracts IP
 from the Modem entity. The IMEI, EID, ICCID, and IMSI remain: they are facts
@@ -523,11 +527,12 @@ center. A remote eSIM management platform pushes a new profile to the eUICC. The
 ICCID and IMSI change; the old data session is torn down. The platform sees the
 new IMSI appear on the same IMEI and asserts the updated profile identifiers.
 Because the old IP belonged to the previous profile's session, it is retracted.
-The EID stays the same: the eUICC chip did not change, only the profile stored on
-it.
+The EID stays the same: the eUICC chip did not change, only the profile stored
+on it.
 
 This is not a telemetry event. It is a network-layer observation: the platform
-sees the IMEI re-attach with a different IMSI. No application payload is involved.
+sees the IMEI re-attach with a different IMSI. No application payload is
+involved.
 
 ### Decommission
 
@@ -545,27 +550,28 @@ stale value is still better than nothing.
 
 Consider a fleet dispatcher looking for scooter `WMX00042`, which went silent 40
 minutes ago. The live model shows no location (retracted after 15 minutes). But
-the *last reported* position, Rabin Square at 14:15, is still the best guess for
+the _last reported_ position, Rabin Square at 14:15, is still the best guess for
 where a technician should start looking. Similarly, the last reported battery
 level (84%) tells the dispatcher whether the scooter is worth retrieving or
 already depleted.
 
-Not every property benefits from this treatment. The table below names properties
-after the domain model, then describes what "last reported" means for each:
+Not every property benefits from this treatment. The table below names
+properties after the domain model, then describes what "last reported" means for
+each:
 
-| Property | Last reported useful? | Notes |
-|----------|---------------------|-------|
-| **GNSS fix** | Yes | The scooter's GPS position (lat, lng, altitude, precision). This is the primary geolocation source. A 40-minute-old fix is still the best starting point for a field technician searching for a silent scooter. |
-| **Serving cell** | Yes | The modem's serving cell (PLMN, tracking area, cell ID, signal strength). Provides a coarse geolocation estimate when GNSS is unavailable. This data comes from the network tap, not from the scooter's telemetry (the scooter software has no access to radio-level data). The last reported serving cell is not the only source of coarse position; see below. |
-| **Battery** | Moderate | The full BMS reading (serial, SoC, voltage, temperature, cycles). Helps prioritize which scooters need attention, but a stale level may be outdated by a swap or charging event the platform missed. |
-| **Speed** | No | Stale speed is misleading; you care about current or nothing. |
-| **InRide** | No | Stale ride status is unreliable. |
-| **IP** | No | Stale IP is likely reassigned to another device. |
+| Property         | Last reported useful? | Notes                                                                                                                                                                                                                                                                                                                                                            |
+| ---------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **GNSS fix**     | Yes                   | The scooter's GPS position (lat, lng, altitude, precision). This is the primary geolocation source. A 40-minute-old fix is still the best starting point for a field technician searching for a silent scooter.                                                                                                                                                  |
+| **Serving cell** | Yes                   | The modem's serving cell (PLMN, tracking area, cell ID, signal strength). Provides a coarse geolocation estimate when GNSS is unavailable. This data comes from the network tap, not from the scooter's telemetry (the scooter software has no access to radio-level data). The last reported serving cell is not the only source of coarse position; see below. |
+| **Battery**      | Moderate              | The full BMS reading (serial, SoC, voltage, temperature, cycles). Helps prioritize which scooters need attention, but a stale level may be outdated by a swap or charging event the platform missed.                                                                                                                                                             |
+| **Speed**        | No                    | Stale speed is misleading; you care about current or nothing.                                                                                                                                                                                                                                                                                                    |
+| **InRide**       | No                    | Stale ride status is unreliable.                                                                                                                                                                                                                                                                                                                                 |
+| **IP**           | No                    | Stale IP is likely reassigned to another device.                                                                                                                                                                                                                                                                                                                 |
 
 Note that the high-value properties (GNSS fix, serving cell, battery) are wide:
-they are structured objects with multiple fields, not scalars. "Last reported GNSS
-fix" means the entire `gnss` struct from the most recent telemetry report that
-had a valid fix, including its precision metadata (`hdop`, `sats`, `fix`).
+they are structured objects with multiple fields, not scalars. "Last reported
+GNSS fix" means the entire `gnss` struct from the most recent telemetry report
+that had a valid fix, including its precision metadata (`hdop`, `sats`, `fix`).
 "Last reported serving cell" means the network tap's most recent observation for
 that scooter's modem, a different instrument with its own retention semantics.
 
@@ -573,36 +579,36 @@ that scooter's modem, a different instrument with its own retention semantics.
 
 The properties above live in the domain model as-is (GNSS fix on the vehicle,
 serving cell on the modem). But fleet operations often want a single answer:
-"where is this scooter?" That answer, a *geolocation*, is derived from whichever
+"where is this scooter?" That answer, a _geolocation_, is derived from whichever
 source is available, in rough priority order:
 
-1. **GNSS fix** — highest precision (meters), from the scooter's GPS receiver via
-   telemetry.
-2. **Serving cell** — coarse (hundreds of meters to kilometers), from the network
-   tap's observation of the modem's cell attachment. During a BLE-bridged ride, the
-   rider's phone may contribute its own serving cell if the operator's app has
-   telephony API permissions; otherwise this field is unavailable for phone-bridged
-   scooters.
+1. **GNSS fix** — highest precision (meters), from the scooter's GPS receiver
+   via telemetry.
+2. **Serving cell** — coarse (hundreds of meters to kilometers), from the
+   network tap's observation of the modem's cell attachment. During a
+   BLE-bridged ride, the rider's phone may contribute its own serving cell if
+   the operator's app has telephony API permissions; otherwise this field is
+   unavailable for phone-bridged scooters.
 3. **Signaling triangulation** — moderate precision, derived from network
    signaling associated with the IMSI (e.g., timing advance, neighboring cell
    measurements). This is exclusively a network-side observation.
 
 Each of these sources has different precision, freshness, and availability. Note
-that sources 2 and 3 come from the network tap, not from the scooter's telemetry;
-they have independent refresh rates and retention semantics. The platform could
-maintain a composite "best available geolocation" that selects the best source, or
-leave the fusion to downstream consumers querying the individual properties. This
-is a design question for implementation.
+that sources 2 and 3 come from the network tap, not from the scooter's
+telemetry; they have independent refresh rates and retention semantics. The
+platform could maintain a composite "best available geolocation" that selects
+the best source, or leave the fusion to downstream consumers querying the
+individual properties. This is a design question for implementation.
 
 ### How to Provide Last Reported Values
 
 Three approaches, each with different trade-offs:
 
 **Separate entity.** A dedicated entity type (e.g., a "last reported position"
-keyed on VIN) that is asserted alongside the spot value but is not subject to the
-same TTL. It carries its own timestamp ("as of when?") and is only overwritten by
-the next valid observation, never retracted by timeout. Clean separation, but
-doubles the number of entities for each property that needs it.
+keyed on VIN) that is asserted alongside the spot value but is not subject to
+the same TTL. It carries its own timestamp ("as of when?") and is only
+overwritten by the next valid observation, never retracted by timeout. Clean
+separation, but doubles the number of entities for each property that needs it.
 
 **Additional fields on the same entity.** The Vehicle carries both `Location`
 (current, retractable) and `LastReportedLocation` (persistent until next
@@ -615,13 +621,13 @@ clear only the current one.
 snapshot per entity. "Last reported location" is a query: find the most recent
 snapshot where location was non-null. This requires no additional live entities
 and no Go struct changes. The trade-off is latency: the answer is only as fresh
-as the last silver rebuild, and consumers must query Parquet rather than subscribe
-to a live NATS stream.
+as the last silver rebuild, and consumers must query Parquet rather than
+subscribe to a live NATS stream.
 
 The right approach may vary by property. Geolocation, the highest-value case,
-could justify a live entity. Battery level, with moderate value and higher risk of being
-outdated, may be fine as an analytics query. The decision is deferred to
-implementation.
+could justify a live entity. Battery level, with moderate value and higher risk
+of being outdated, may be fine as an analytics query. The decision is deferred
+to implementation.
 
 ## Competing Knowledge
 
@@ -629,8 +635,8 @@ Not everything the platform knows is certain. When two classifiers assert
 different operators for the same modem (say, the DNS classifier sees `lime.com`
 but the IMSI-range analyzer maps the prefix to Bird), both assertions coexist.
 Each has its own source identifier, confidence score, and deployment version.
-Downstream consumers decide how to reconcile: pick the highest confidence, require
-agreement, or flag the conflict.
+Downstream consumers decide how to reconcile: pick the highest confidence,
+require agreement, or flag the conflict.
 
 This is not a bug; it is a feature of the domain. The real world is ambiguous.
 Scooters are reflashed and resold between operators. SIM plans are occasionally
@@ -642,43 +648,43 @@ rather than forcing premature resolution.
 ## Overlapping Observations
 
 A digital twin system observes the same physical entities from multiple
-independent vantage points. The scooter's IP address appears in two places:
-the OS network stack (telemetry) and the network tap (signaling). The modem's
-IMEI is reported by AT commands in the telemetry payload and observed directly
-by the network tap. The battery serial comes from the BMS chip via telemetry
-and from the operator's asset database via the vendor instrument.
+independent vantage points. The scooter's IP address appears in two places: the
+OS network stack (telemetry) and the network tap (signaling). The modem's IMEI
+is reported by AT commands in the telemetry payload and observed directly by the
+network tap. The battery serial comes from the BMS chip via telemetry and from
+the operator's asset database via the vendor instrument.
 
 This overlap is not redundant; it is the system's primary source of insight.
 When independent observations agree, the agreement is a positive reinforcement
 signal: the system's model of the world is consistent. When they disagree, the
 discrepancy is equally valuable. An IP mismatch between telemetry and the
-network tap may indicate a stale session, a NAT traversal, or a
-miscorrelation. A battery serial that the telemetry reports but the vendor
-instrument does not recognize may indicate an unregistered replacement part.
+network tap may indicate a stale session, a NAT traversal, or a miscorrelation.
+A battery serial that the telemetry reports but the vendor instrument does not
+recognize may indicate an unregistered replacement part.
 
 Higher-order mechanisms built on top of the digital twin (anomaly detection,
 compliance auditing, fleet analytics) consume these signals. The twin itself
 does not resolve them; it holds all observations faithfully and lets downstream
 consumers decide what the disagreement means. This is why the domain model
 maintains separate entities for each observation perspective (Modem from the
-network tap, Vehicle from telemetry, classifications from automated
-classifiers) rather than merging them into a single canonical record. The
-separation preserves the provenance that makes corroboration and conflict
-detection possible.
+network tap, Vehicle from telemetry, classifications from automated classifiers)
+rather than merging them into a single canonical record. The separation
+preserves the provenance that makes corroboration and conflict detection
+possible.
 
 ## Variance
 
 The scooter domain has many axes of variation, and the platform must handle them
 all without requiring a uniform data source.
 
-| Axis | Range | Effect on observability |
-|------|-------|------------------------|
-| **Operator** | Lime, Bird, Dot, others | Different firmware, payload formats, reporting intervals |
+| Axis                    | Range                                           | Effect on observability                                          |
+| ----------------------- | ----------------------------------------------- | ---------------------------------------------------------------- |
+| **Operator**            | Lime, Bird, Dot, others                         | Different firmware, payload formats, reporting intervals         |
 | **Hardware generation** | Gen 1 (BLE-only) through Gen 4 (cellular + BLE) | Gen 1 has no modem; no persistent network identity between rides |
-| **Connectivity** | Cellular, phone-bridged, hybrid, WiFi-at-dock | Determines whether a stable Modem entity exists |
-| **Carrier** | Multiple MNOs per region | Different IMSI prefixes, APN configurations, IP address pools |
-| **Coverage** | Full signal to dead zones | Observation gaps; properties go stale at different rates |
-| **Firmware version** | Operator-specific, updated OTA | Payload structure and trigger logic may differ between versions |
+| **Connectivity**        | Cellular, phone-bridged, hybrid, WiFi-at-dock   | Determines whether a stable Modem entity exists                  |
+| **Carrier**             | Multiple MNOs per region                        | Different IMSI prefixes, APN configurations, IP address pools    |
+| **Coverage**            | Full signal to dead zones                       | Observation gaps; properties go stale at different rates         |
+| **Firmware version**    | Operator-specific, updated OTA                  | Payload structure and trigger logic may differ between versions  |
 
 The delta model (assert/retract/ignore) absorbs this variance naturally: the
 platform asserts what it can observe, ignores what it cannot, and retracts what
@@ -690,13 +696,13 @@ longer gaps between updates.
 
 The tangible objects that interact in this world:
 
-| Character | Identity | Lifetime | What changes |
-|-----------|----------|----------|--------------|
-| **Modem** | IMEI (hardware), EID (eUICC) | Permanent — manufactured into the scooter | eSIM profile (ICCID, IMSI), IP session, firmware |
-| **Vehicle** | VIN (frame) | Permanent — stamped at manufacture | Which modem is installed, speed, location, ride status |
-| **Battery** | Serial number (BMS chip) | Permanent — printed on casing | Which vehicle it is installed in, charge level, cycle count |
-| **Operator classification** | IMEI + classifier source | Per classifier assertion | Which operator, confidence, classifier version |
-| **Model classification** | IMEI + classifier source | Per classifier assertion | Manufacturer, model designation, confidence |
+| Character                   | Identity                     | Lifetime                                  | What changes                                                |
+| --------------------------- | ---------------------------- | ----------------------------------------- | ----------------------------------------------------------- |
+| **Modem**                   | IMEI (hardware), EID (eUICC) | Permanent — manufactured into the scooter | eSIM profile (ICCID, IMSI), IP session, firmware            |
+| **Vehicle**                 | VIN (frame)                  | Permanent — stamped at manufacture        | Which modem is installed, speed, location, ride status      |
+| **Battery**                 | Serial number (BMS chip)     | Permanent — printed on casing             | Which vehicle it is installed in, charge level, cycle count |
+| **Operator classification** | IMEI + classifier source     | Per classifier assertion                  | Which operator, confidence, classifier version              |
+| **Model classification**    | IMEI + classifier source     | Per classifier assertion                  | Manufacturer, model designation, confidence                 |
 
 Note that the Modem and Vehicle are observed through independent channels
 (network layer vs application layer). For cellular-connected scooters, both

--- a/samples/micromobility/README.md
+++ b/samples/micromobility/README.md
@@ -255,13 +255,27 @@ wider network: the interface through which data reaches the operator's backend.
 Its internal structure varies by connectivity type:
 
 - **Cellular** (`"cellular"`): the built-in modem. The scooter's software can
-  always read the modem's IP address from the OS network stack. The IMEI and IMSI
-  may be available if the firmware queries the modem via standard AT commands
-  (`AT+CGSN`, `AT+CIMI`); many embedded platforms expose this unprivileged, but
-  it is not guaranteed. eSIM-level identifiers (EID, ICCID) are generally not
-  accessible through the AT interface. The software has no access to radio-level
-  data (serving cell, signal quality, neighbor cells); that information exists
-  only on the network side.
+  always read the modem's IP address from the OS network stack. Beyond the IP,
+  3GPP TS 27.007 standardizes a set of AT commands that the firmware can use to
+  query the modem, though not every modem or firmware implements the full spec:
+
+  | AT Command | Data | Notes |
+  |------------|------|-------|
+  | `AT+CGSN` | IMEI | Modem hardware identity |
+  | `AT+CIMI` | IMSI | Subscriber identity from the active profile |
+  | `AT+COPS` | Registered operator (PLMN) | Operator name or MCC-MNC |
+  | `AT+CREG` / `AT+CEREG` | Registration status | Whether the modem is registered, roaming, or searching |
+  | `AT+CGDCONT` | APN / PDP context | Data session configuration |
+  | `AT+CGATT` | Attach status | Whether the modem is attached to packet services |
+  | `AT+CGMI`, `AT+CGMM`, `AT+CGMR` | Modem manufacturer, model, firmware | Hardware and software identification of the modem itself |
+
+  All of these are best-effort from the telemetry perspective: the firmware may
+  not query them, the modem may not implement them fully, and the values may lag
+  behind the network's own view of the same session. eSIM-level identifiers (EID,
+  ICCID) are generally not accessible through the standard AT interface. Signal
+  quality metrics (RSRP, RSRQ), neighbor cell measurements, and handover events
+  are not available through standard commands; that information exists only on the
+  network side.
 - **Bluetooth** (`"bluetooth"`): the rider's phone acting as a relay. Identified
   by the phone's BLE device name (the Local Name advertised during pairing).
 - **Station** (`"station"`): a fixed infrastructure access point, typically WiFi

--- a/samples/micromobility/README.md
+++ b/samples/micromobility/README.md
@@ -200,16 +200,21 @@ it was delivered.
 | Instrument | Data | Refresh | Identity anchor |
 |------------|------|---------|-----------------|
 | **Vendor instrument** | VIN, fleet ID, hardware generation, modem assignment | On provisioning events | VIN (vehicle frame) |
-| **Network tap** | IMEI, IMSI, IP, serving cell, DNS queries | On network events (real-time) | IMEI (modem) |
-| **Telemetry feed** | Device ID, GNSS, speed, battery, accelerometer, access point | Per report (real-time or batched) | device_id (fleet ID or VIN) |
+| **Network tap** | IMEI, IMSI, IP, serving cell, signal quality, DNS queries | On network events (real-time) | IMEI (modem) |
+| **Telemetry feed** | Device ID, GNSS, speed, battery, accelerometer, point of attachment (IP, modem IDs if available, BLE device name, dock ID) | Per report (real-time or batched) | device_id (fleet ID or VIN) |
 
-These instruments observe through independent channels. For cellular-connected
-scooters, the platform correlates them: the vendor instrument says "VIN
-`WMX00042` has IMEI `353456789012345`," the network tap sees that IMEI attach to
-the network, and the telemetry feed delivers application payloads keyed on the
-same device. For phone-bridged scooters, only the telemetry feed (relayed through
-the operator's backend) may be available; the vendor instrument provides the
-stable identity that the network layer cannot.
+These instruments observe through independent channels. The IP address is the
+primary bridge between them: the scooter's software always knows its IP (the OS
+provides it), the network tap knows which IMEI holds which IP session, and the
+vendor instrument maps the IMEI to a VIN. For cellular-connected scooters, the
+full correlation chain is: VIN → IMEI (vendor), IMEI → IP (network tap),
+telemetry source IP → device_id (telemetry feed). If the scooter's firmware also
+queries the modem's IMEI via AT commands, the telemetry `access` field provides a
+direct confirmation, but the IP-based correlation does not depend on it.
+
+For phone-bridged scooters, only the telemetry feed (relayed through the
+operator's backend) may be available; the vendor instrument provides the stable
+identity that the network layer cannot.
 
 ## Telemetry Events
 
@@ -246,22 +251,26 @@ fields below use standard abbreviations from IoT and vehicle telematics:
 | `accel.tilt` | float64 | Tilt angle in degrees (0 = upright, 90 = on its side) |
 
 The `access` field describes the scooter's current **point of attachment** to the
-wider network: the intermediate node through which data reaches the operator's
-backend. Its internal structure varies by connectivity type:
+wider network: the interface through which data reaches the operator's backend.
+Its internal structure varies by connectivity type:
 
-- **Cellular** (`"cellular"`): the *serving cell*, the cell tower sector the modem
-  is camped on. Identified by PLMN, tracking area, and cell ID. Includes signal
-  quality (RSRP).
+- **Cellular** (`"cellular"`): the built-in modem. The scooter's software can
+  always read the modem's IP address from the OS network stack. Modem identifiers
+  (IMEI, EID, ICCID, IMSI) may be available if the firmware queries the modem's
+  AT command interface; many embedded platforms expose this unprivileged, but it is
+  not guaranteed. The software has no access to radio-level data (serving cell,
+  signal quality, neighbor cells); that information exists only on the network
+  side.
 - **Bluetooth** (`"bluetooth"`): the rider's phone acting as a relay. Identified
-  by a peer identifier. Includes signal quality (RSSI).
+  by the phone's BLE device name (the Local Name advertised during pairing).
 - **Station** (`"station"`): a fixed infrastructure access point, typically WiFi
-  at a docking station. Identified by the AP's address. Includes signal quality
-  (RSSI).
+  at a docking station. Identified by the station's network identifier (BSSID or
+  operator-assigned dock ID).
 
 The scooter's software includes the current access point in each telemetry report
-when available. When the point of attachment changes (cell handover, new phone
-pairs, docking station connects) or its properties update meaningfully, a
-dedicated trigger fires (see [Triggers](#triggers)).
+when available. When the point of attachment changes in a way the software can
+observe (IP reassignment after a cellular reconnect, new phone pairs, docking
+station connects), a dedicated trigger fires (see [Triggers](#triggers)).
 
 Not every field is present in every report. The scooter's software omits fields it
 cannot populate (e.g., `gnss.*` when there is no satellite fix, `access` on
@@ -299,8 +308,7 @@ the reporting frequency and the `accel.motion` flag.
 | `impact` | Accelerometer spike exceeds impact threshold (fall or collision) |
 | `battery_swap` | BMS reports a different battery serial after power cycle |
 | `low_battery` | State of charge drops below configured threshold |
-| `access_change` | Point of attachment changes (cell handover, new phone, dock connect) |
-| `access_update` | Same point of attachment, signal quality or properties refreshed |
+| `access_update` | Connectivity change that requires immediate attention (new IP after cellular reconnect, new phone pairs via BLE, docking station connects) |
 | `gnss_fix` | GNSS acquires a fix after a period with no fix |
 | `power_on` | Scooter boots after battery insertion or deep sleep wake |
 
@@ -406,23 +414,27 @@ payload-structure classifier recognizes the telemetry encoding as Segway Max G30
 firmware and asserts a model classification. Three classifiers, three independent
 assertions, all keyed on the same IMEI.
 
-### Mid-Ride: Cell Handover
+### Mid-Ride: IP Reassignment
 
-The rider crosses into a different cell sector. The network hands over the
-session. The scooter's software detects the change in point of attachment:
+The rider passes through a coverage gap. The modem loses its data session and
+re-attaches to the network, receiving a new IP. The scooter's software notices
+the IP change on its network interface and fires an access update:
 
 ```
-{device_id: "WMX00042", ts: "08:22:17Z", seq: 81244, trigger: "access_change",
+{device_id: "WMX00042", ts: "08:22:17Z", seq: 81244, trigger: "access_update",
  gnss: {lat: 32.0812, lng: 34.7801, fix: "3d", hdop: 0.8, sats: 12},
  speed: 16.4, heading: 12,
  battery: {id: "BAT-2187", soc: 0.91, ..},
- access: {type: "cellular", mcc: 425, mnc: 01, tac: 12401, cid: 52417, rsrp: -78},
+ access: {type: "cellular", ip: "100.72.31.88", imei: "353456789012345"},
  accel: {motion: true, ..}}
 ```
 
-At the network layer, the IP changes from `100.72.14.201` to `100.72.31.88`.
-The IMEI and IMSI remain the same. The platform asserts the new IP on the Modem
-entity; the old IP is overwritten by the new assertion.
+The scooter knows its new IP (the OS provides it) and its IMEI (queried via AT
+commands on this hardware). It does not know *why* the IP changed: cell handover,
+session timeout, or carrier-side reassignment are all invisible at the
+application layer. At the network layer, the platform's tap sees the same IMEI
+re-attach with the new IP; it correlates the telemetry flowing from `100.72.31.88`
+with the existing Modem entity.
 
 ### Ride Ends
 
@@ -455,18 +467,24 @@ idle heartbeats (speed 0, same location), keeping its properties fresh:
 ```
 
 Now imagine the scooter gets moved into a parking garage by an overzealous
-building manager. The GNSS fix degrades, then disappears. The cellular signal
-weakens. Eventually, the scooter's software cannot send at all:
+building manager. The GNSS fix degrades, then disappears. The scooter's last
+report before silence:
 
 ```
 {device_id: "WMX00042", ts: "14:15:42Z", seq: 81793, trigger: "periodic",
  gnss: {fix: "none"},
  battery: {id: "BAT-2187", soc: 0.84, ..},
- access: {type: "cellular", mcc: 425, mnc: 01, tac: 12401, cid: 52418, rsrp: -112},
  accel: {motion: false, tilt: 2.1}}
 
 ... then silence.
 ```
+
+The scooter's software has no visibility into the cellular signal degradation that
+causes the silence. It simply cannot send. The signal loss is observable from the
+network side: the platform's tap sees the IMSI's radio conditions deteriorate
+(weak RSRP, handover failures) and eventually the session drop. This
+supplementary instrumentation, correlated with the modem's IMSI, provides the
+radio context that the scooter's own telemetry cannot.
 
 After the configured telemetry TTL expires (say, 15 minutes with no beacon), the
 platform retracts Speed, Location, and InRide. The scooter still exists in the
@@ -523,7 +541,7 @@ after the domain model, then describes what "last reported" means for each:
 | Property | Last reported useful? | Notes |
 |----------|---------------------|-------|
 | **GNSS fix** | Yes | The scooter's GPS position (lat, lng, altitude, precision). This is the primary geolocation source. A 40-minute-old fix is still the best starting point for a field technician searching for a silent scooter. |
-| **Serving cell** | Yes | The modem's serving cell (PLMN, tracking area, cell ID, signal strength). Provides a coarse geolocation estimate when GNSS is unavailable. But the last reported serving cell is not the only source of coarse position; see below. |
+| **Serving cell** | Yes | The modem's serving cell (PLMN, tracking area, cell ID, signal strength). Provides a coarse geolocation estimate when GNSS is unavailable. This data comes from the network tap, not from the scooter's telemetry (the scooter software has no access to radio-level data). The last reported serving cell is not the only source of coarse position; see below. |
 | **Battery** | Moderate | The full BMS reading (serial, SoC, voltage, temperature, cycles). Helps prioritize which scooters need attention, but a stale level may be outdated by a swap or charging event the platform missed. |
 | **Speed** | No | Stale speed is misleading; you care about current or nothing. |
 | **InRide** | No | Stale ride status is unreliable. |
@@ -533,6 +551,8 @@ Note that the high-value properties (GNSS fix, serving cell, battery) are wide:
 they are structured objects with multiple fields, not scalars. "Last reported GNSS
 fix" means the entire `gnss` struct from the most recent telemetry report that
 had a valid fix, including its precision metadata (`hdop`, `sats`, `fix`).
+"Last reported serving cell" means the network tap's most recent observation for
+that scooter's modem, a different instrument with its own retention semantics.
 
 ### Geolocation as a Derived View
 
@@ -541,18 +561,23 @@ serving cell on the modem). But fleet operations often want a single answer:
 "where is this scooter?" That answer, a *geolocation*, is derived from whichever
 source is available, in rough priority order:
 
-1. **GNSS fix** — highest precision (meters), from the scooter's GPS receiver.
-2. **Serving cell** — coarse (hundreds of meters to kilometers), from the modem's
-   last reported cell attachment or from the rider's phone during a BLE-bridged
-   ride.
+1. **GNSS fix** — highest precision (meters), from the scooter's GPS receiver via
+   telemetry.
+2. **Serving cell** — coarse (hundreds of meters to kilometers), from the network
+   tap's observation of the modem's cell attachment. During a BLE-bridged ride, the
+   rider's phone may contribute its own serving cell if the operator's app has
+   telephony API permissions; otherwise this field is unavailable for phone-bridged
+   scooters.
 3. **Signaling triangulation** — moderate precision, derived from network
    signaling associated with the IMSI (e.g., timing advance, neighboring cell
-   measurements).
+   measurements). This is exclusively a network-side observation.
 
-Each of these sources has different precision, freshness, and availability. The
-platform could maintain a composite "best available geolocation" that selects the
-best source, or leave the fusion to downstream consumers querying the individual
-properties. This is a design question for implementation.
+Each of these sources has different precision, freshness, and availability. Note
+that sources 2 and 3 come from the network tap, not from the scooter's telemetry;
+they have independent refresh rates and retention semantics. The platform could
+maintain a composite "best available geolocation" that selects the best source, or
+leave the fusion to downstream consumers querying the individual properties. This
+is a design question for implementation.
 
 ### How to Provide Last Reported Values
 

--- a/samples/micromobility/README.md
+++ b/samples/micromobility/README.md
@@ -357,6 +357,75 @@ replacement).
 ·      ·    ·    ·    ·  · · · · ·  · · · · ·  · · · · ·   · ·  ·  ·     ·
 ```
 
+## Systems
+
+The following diagram fixes the systems referenced throughout the narrative.
+Solid arrows are continuous flows (telemetry, signaling, registry records);
+dashed arrows are intermittent paths (BLE relay, WiFi at docks) or out-of-band
+provisioning events (eSIM profile pushes).
+
+```mermaid
+flowchart LR
+    subgraph Scooter
+        FW["Firmware / control board"]
+        GNSS["GNSS receiver"]
+        Accel[Accelerometer]
+        BMS[BMS chip]
+        Battery["Swappable pack"]
+        Modem["Cellular modem + eUICC"]
+        FW --- GNSS
+        FW --- Accel
+        FW --- BMS
+        FW --- Modem
+        BMS --- Battery
+    end
+
+    subgraph Cellular["Cellular network"]
+        RAN["Base stations / RAN"]
+        Core["Packet core"]
+        eSIM["eSIM management"]
+    end
+
+    Phone["Rider phone (BLE)"]
+    Dock["Docking station (WiFi)"]
+
+    subgraph Backend["Operator backend"]
+        Provisioning["Provisioning registry"]
+        Ingest["Telemetry ingestion"]
+    end
+
+    subgraph Platform["Observation platform"]
+        VI["Vendor instrument"]
+        NT["Network tap"]
+        TF["Telemetry feed"]
+        Twin["Digital twin"]
+        Analytics["Silver / gold tiers"]
+        VI --> Twin
+        NT --> Twin
+        TF --> Twin
+        Twin --> Analytics
+    end
+
+    Modem ==> RAN
+    RAN ==> Core
+    Core ==> Ingest
+    FW -. BLE .-> Phone
+    Phone ==> Ingest
+    FW -. WiFi .-> Dock
+    Dock ==> Ingest
+    eSIM -. profile push .-> Modem
+
+    Provisioning --> VI
+    Core --> NT
+    Ingest --> TF
+```
+
+The platform is the rightmost grouping; everything to its left is a source it
+observes. Each instrument is anchored on a different identifier (VIN for the
+vendor instrument, IMEI for the network tap, `device_id` for the telemetry
+feed), and the digital twin is where those independent observations are
+correlated.
+
 ## A Scooter's Day
 
 The following traces one cellular-connected scooter through a full day. This is

--- a/samples/micromobility/README.md
+++ b/samples/micromobility/README.md
@@ -228,28 +228,32 @@ generation, but the general patterns are consistent across the industry.
 Each telemetry report carries a common envelope and a set of sensor readings.
 The fields below use standard abbreviations from IoT and vehicle telematics:
 
-| Field                  | Type     | Description                                           |
-| ---------------------- | -------- | ----------------------------------------------------- |
-| `device_id`            | string   | Scooter identity (VIN or operator-assigned fleet ID)  |
-| `ts`                   | ISO 8601 | Timestamp at the scooter's clock                      |
-| `seq`                  | uint32   | Monotonic sequence number; gaps reveal lost reports   |
-| `trigger`              | string   | Why this report was sent (see [Triggers](#triggers))  |
-| `gnss.lat`, `gnss.lng` | float64  | WGS 84 coordinates                                    |
-| `gnss.alt`             | float64  | Altitude in meters above sea level                    |
-| `gnss.hdop`            | float64  | Horizontal dilution of precision (lower is better)    |
-| `gnss.sats`            | uint8    | Satellites used in the fix                            |
-| `gnss.fix`             | string   | Fix quality: `"none"`, `"2d"`, `"3d"`                 |
-| `speed`                | float64  | Ground speed in km/h (GNSS-derived)                   |
-| `heading`              | float64  | Course over ground in degrees, 0–360                  |
-| `battery.id`           | string   | BMS-reported serial number of the installed pack      |
-| `battery.soc`          | float64  | State of charge, 0.0–1.0                              |
-| `battery.voltage`      | float64  | Pack voltage in volts                                 |
-| `battery.temp`         | int      | Cell temperature in °C                                |
-| `battery.cycles`       | uint32   | Lifetime charge cycle count                           |
-| `odometer`             | float64  | Cumulative trip distance in km                        |
-| `access`               | object   | Current point of attachment (see below)               |
-| `accel.motion`         | bool     | Accelerometer motion detection flag                   |
-| `accel.tilt`           | float64  | Tilt angle in degrees (0 = upright, 90 = on its side) |
+| Field                   | Type     | Description                                                                   |
+| ----------------------- | -------- | ----------------------------------------------------------------------------- |
+| `device_id`             | string   | Scooter identity (VIN or operator-assigned fleet ID)                          |
+| `ts`                    | ISO 8601 | Timestamp at the scooter's clock                                              |
+| `seq`                   | uint32   | Monotonic sequence number; gaps reveal lost reports                           |
+| `trigger`               | string   | Why this report was sent (see [Triggers](#triggers))                          |
+| `gnss.lat`, `gnss.lng`  | float64  | WGS 84 coordinates                                                            |
+| `gnss.alt`              | float64  | Altitude in meters above sea level                                            |
+| `gnss.hdop`             | float64  | Horizontal dilution of precision (lower is better)                            |
+| `gnss.sats`             | uint8    | Satellites used in the fix                                                    |
+| `gnss.fix`              | string   | Fix quality: `"none"`, `"2d"`, `"3d"`                                         |
+| `speed`                 | float64  | Ground speed in km/h (GNSS-derived)                                           |
+| `heading`               | float64  | Course over ground in degrees, 0–360                                          |
+| `battery.id`            | string   | BMS-reported serial number of the installed pack                              |
+| `battery.soc`           | float64  | State of charge, 0.0–1.0                                                      |
+| `battery.voltage`       | float64  | Pack voltage in volts                                                         |
+| `battery.design_energy` | uint32   | Design full-charge energy when new, in mWh (factory rating)                   |
+| `battery.full_energy`   | uint32   | Latest measured full-charge capacity, in mWh (degrades with cycles)           |
+| `battery.energy`        | uint32   | Current stored energy, in mWh                                                 |
+| `battery.power`         | int      | Instantaneous power flow in mW (positive while charging, negative under load) |
+| `battery.temp`          | int      | Cell temperature in °C                                                        |
+| `battery.cycles`        | uint32   | Lifetime charge cycle count                                                   |
+| `odometer`              | float64  | Cumulative trip distance in km                                                |
+| `access`                | object   | Current point of attachment (see below)                                       |
+| `accel.motion`          | bool     | Accelerometer motion detection flag                                           |
+| `accel.tilt`            | float64  | Tilt angle in degrees (0 = upright, 90 = on its side)                         |
 
 The `access` field describes the scooter's current **point of attachment** to
 the wider network: the interface through which data reaches the operator's
@@ -292,6 +296,15 @@ pairs, docking station connects), a dedicated trigger fires (see
 Not every field is present in every report. The scooter's software omits fields
 it cannot populate (e.g., `gnss.*` when there is no satellite fix, `access` on
 scooters with no active connectivity metadata).
+
+The battery sub-fields are partially redundant: `battery.energy` divided by
+`battery.full_energy` is the state of charge, and `battery.full_energy` trends
+down from `battery.design_energy` over the pack's life as cycles accumulate.
+Real BMSs expose different subsets of these readings: some surface only a
+percentage, others publish the underlying energies and an instantaneous
+`battery.power`. The digested domain model holds a single normalized state of
+charge derived from whichever measurements the instrument provides; the raw
+fields stay in the analytics tier for downstream battery health analysis.
 
 The `device_id` is the application-layer identity of the scooter. It is
 independent of the IMEI: the IMEI belongs to the modem at the network layer,

--- a/samples/micromobility/classify/classify.go
+++ b/samples/micromobility/classify/classify.go
@@ -3,13 +3,14 @@
 //
 // The observation platform runs multiple independent classifiers (DNS
 // fingerprinting, IMSI-range analysis, payload-structure recognition) that
-// may disagree. Both an Operator and a Model assertion carry a Source, a
-// Confidence score, and a classifier Version so that downstream consumers
-// can reconcile conflicts without forcing premature resolution.
-//
-// These types are placeholders; naming and structure will be refined once
-// the classification story is fleshed out.
+// may disagree. Both an [Operator] and a [Model] assertion embed
+// [fingerprint.Classification], which provides the classifier's [fingerprint.Signature]
+// (type and deployment version), an Active flag, and a Confidence score so
+// that downstream consumers can reconcile conflicts without forcing premature
+// resolution.
 package classify
+
+import "github.com/go-digitaltwin/v2-experiment/fingerprint"
 
 // Operator records one classifier's assertion about which fleet operator
 // runs the scooter behind a given modem.
@@ -19,20 +20,16 @@ package classify
 // assertions coexist; the composite key (IMEI + Source) keeps them
 // separate.
 type Operator struct {
-	IMEI       string  // Key. Modem identity being classified.
-	Source     string  // Key. Classifier identity (e.g. "dns-fingerprint", "imsi-range").
-	Operator   string  // Asserted operator name (e.g. "Lime", "Bird", "Dot").
-	Confidence float64 // Classifier confidence, 0.0 to 1.0.
-	Version    string  // Classifier deployment version (e.g. "v2.3").
+	IMEI     string // Key. Modem identity being classified.
+	Operator string // Asserted operator name (e.g. "Lime", "Bird", "Dot").
+	fingerprint.Classification
 }
 
 // Model records one classifier's assertion about the hardware
 // manufacturer and model designation behind a given modem.
 type Model struct {
-	IMEI         string  // Key. Modem identity being classified.
-	Source       string  // Key. Classifier identity.
-	Manufacturer string  // Asserted hardware manufacturer (e.g. "Segway").
-	Model        string  // Asserted model designation (e.g. "Max G30").
-	Confidence   float64 // Classifier confidence, 0.0 to 1.0.
-	Version      string  // Classifier deployment version.
+	IMEI         string // Key. Modem identity being classified.
+	Manufacturer string // Asserted hardware manufacturer (e.g. "Segway").
+	Designation  string // Asserted model designation (e.g. "Max G30").
+	fingerprint.Classification
 }

--- a/samples/micromobility/classify/classify.go
+++ b/samples/micromobility/classify/classify.go
@@ -1,0 +1,38 @@
+// Package classify holds assertions that automated classifiers make about
+// modem identity: which operator runs a scooter and what hardware model it is.
+//
+// The observation platform runs multiple independent classifiers (DNS
+// fingerprinting, IMSI-range analysis, payload-structure recognition) that
+// may disagree. Both an Operator and a Model assertion carry a Source, a
+// Confidence score, and a classifier Version so that downstream consumers
+// can reconcile conflicts without forcing premature resolution.
+//
+// These types are placeholders; naming and structure will be refined once
+// the classification story is fleshed out.
+package classify
+
+// Operator records one classifier's assertion about which fleet operator
+// runs the scooter behind a given modem.
+//
+// Multiple classifiers may assert different operators for the same IMEI
+// (e.g., DNS sees lime.com while the IMSI-range maps to Bird). All
+// assertions coexist; the composite key (IMEI + Source) keeps them
+// separate.
+type Operator struct {
+	IMEI       string  // Key. Modem identity being classified.
+	Source     string  // Key. Classifier identity (e.g. "dns-fingerprint", "imsi-range").
+	Operator   string  // Asserted operator name (e.g. "Lime", "Bird", "Dot").
+	Confidence float64 // Classifier confidence, 0.0 to 1.0.
+	Version    string  // Classifier deployment version (e.g. "v2.3").
+}
+
+// Model records one classifier's assertion about the hardware
+// manufacturer and model designation behind a given modem.
+type Model struct {
+	IMEI         string  // Key. Modem identity being classified.
+	Source       string  // Key. Classifier identity.
+	Manufacturer string  // Asserted hardware manufacturer (e.g. "Segway").
+	Model        string  // Asserted model designation (e.g. "Max G30").
+	Confidence   float64 // Classifier confidence, 0.0 to 1.0.
+	Version      string  // Classifier deployment version.
+}

--- a/samples/micromobility/fleet/battery.go
+++ b/samples/micromobility/fleet/battery.go
@@ -9,9 +9,10 @@ package fleet
 // BMS readings in each scooter's telemetry payload. A battery-swap event
 // manifests as a sudden change in the reported serial number.
 type Battery struct {
-	Serial  string  // Primary key. BMS serial number printed on the casing.
-	SoC     float64 // State of charge, 0.0 (empty) to 1.0 (full).
-	Voltage float64 // Pack voltage in volts.
-	Temp    int     // Cell temperature in degrees Celsius.
-	Cycles  uint32  // Lifetime charge-cycle count reported by the BMS.
+	Serial     string  // Primary key. BMS serial number printed on the casing.
+	VehicleVIN string  // Foreign key → [Vehicle]. Which scooter this pack is installed in.
+	SoC        float64 // State of charge, 0.0 (empty) to 1.0 (full).
+	Voltage    float64 // Pack voltage in volts.
+	Temp       int     // Cell temperature in degrees Celsius.
+	Cycles     uint32  // Lifetime charge-cycle count reported by the BMS.
 }

--- a/samples/micromobility/fleet/battery.go
+++ b/samples/micromobility/fleet/battery.go
@@ -1,0 +1,17 @@
+package fleet
+
+// Battery is a swappable lithium-ion pack identified by the serial number
+// on its BMS chip.
+//
+// Batteries circulate independently of vehicles: field technicians swap
+// depleted packs in the street, so a single battery passes through many
+// scooters over its lifetime. The platform learns about batteries from the
+// BMS readings in each scooter's telemetry payload. A battery-swap event
+// manifests as a sudden change in the reported serial number.
+type Battery struct {
+	Serial  string  // Primary key. BMS serial number printed on the casing.
+	SoC     float64 // State of charge, 0.0 (empty) to 1.0 (full).
+	Voltage float64 // Pack voltage in volts.
+	Temp    int     // Cell temperature in degrees Celsius.
+	Cycles  uint32  // Lifetime charge-cycle count reported by the BMS.
+}

--- a/samples/micromobility/fleet/battery.go
+++ b/samples/micromobility/fleet/battery.go
@@ -8,11 +8,15 @@ package fleet
 // scooters over its lifetime. The platform learns about batteries from the
 // BMS readings in each scooter's telemetry payload. A battery-swap event
 // manifests as a sudden change in the reported serial number.
+//
+// The Vehicle→Battery relationship is maintained on [Vehicle] (BatterySerial),
+// not here. If a reverse link (Battery→Vehicle) is ever needed, it will be
+// added as a field with supporting causality mechanisms to keep both sides
+// eventually consistent.
 type Battery struct {
-	Serial     string  // Primary key. BMS serial number printed on the casing.
-	VehicleVIN string  // Foreign key → [Vehicle]. Which scooter this pack is installed in.
-	SoC        float64 // State of charge, 0.0 (empty) to 1.0 (full).
-	Voltage    float64 // Pack voltage in volts.
-	Temp       int     // Cell temperature in degrees Celsius.
-	Cycles     uint32  // Lifetime charge-cycle count reported by the BMS.
+	Serial  string  // Primary key. BMS serial number printed on the casing.
+	SoC     float64 // State of charge, 0.0 (empty) to 1.0 (full).
+	Voltage float64 // Pack voltage in volts.
+	Temp    int     // Cell temperature in degrees Celsius.
+	Cycles  uint32  // Lifetime charge-cycle count reported by the BMS.
 }

--- a/samples/micromobility/fleet/vehicle.go
+++ b/samples/micromobility/fleet/vehicle.go
@@ -8,6 +8,8 @@
 // fleet management systems.
 package fleet
 
+import "net/netip"
+
 // Vehicle is an electric scooter identified by its frame-stamped VIN.
 //
 // The platform observes vehicles through application-layer telemetry: periodic
@@ -26,6 +28,7 @@ type Vehicle struct {
 	Odometer      float64 // Cumulative trip distance in km.
 	AccelMotion   bool    // Accelerometer motion-detection flag.
 	AccelTilt     float64 // Tilt angle in degrees (0 = upright, 90 = on its side).
+	Access        Access  // Current point of attachment to the wider network.
 }
 
 // GNSS holds a satellite fix from the scooter's GPS receiver.
@@ -47,4 +50,34 @@ const (
 	FixNone = "none"
 	Fix2D   = "2d"
 	Fix3D   = "3d"
+)
+
+// Access describes a scooter's current point of attachment to the wider
+// network: the interface through which telemetry reaches the operator's
+// backend.
+//
+// The connectivity model varies by operator and hardware generation. A
+// scooter with a built-in cellular modem maintains a persistent data session
+// even when idle; a phone-bridged scooter communicates only during rides
+// through the rider's phone; a docked scooter uploads buffered telemetry
+// over station WiFi.
+//
+// The Type field selects the variant; fields belonging to other variants are
+// at their zero values.
+type Access struct {
+	Type  string     // Connectivity variant: "cellular", "bluetooth", or "station".
+	IP    netip.Addr // Cellular: current data-session IP.
+	IMEI  string     // Cellular: modem IMEI, if the firmware queries the AT interface.
+	EID   string     // Cellular: eUICC chip identity (optional).
+	ICCID string     // Cellular: active eSIM profile (optional).
+	IMSI  string     // Cellular: subscriber identity (optional).
+	BLE   string     // Bluetooth: rider's phone BLE device name (Local Name).
+	BSSID string     // Station: WiFi BSSID or operator-assigned dock ID.
+}
+
+// Access type constants for [Access.Type].
+const (
+	AccessCellular  = "cellular"
+	AccessBluetooth = "bluetooth"
+	AccessStation   = "station"
 )

--- a/samples/micromobility/fleet/vehicle.go
+++ b/samples/micromobility/fleet/vehicle.go
@@ -1,0 +1,48 @@
+// Package fleet defines the physical assets observed through application-layer
+// telemetry: vehicles (scooters), batteries, and their sensors.
+//
+// A shared electric scooter is a small vehicle built around a control board
+// that reads sensors (GPS, accelerometer, BMS) and reports telemetry through
+// whatever network interface is available. The observation platform learns
+// about vehicles from the telemetry payloads they emit, not from operator
+// fleet management systems.
+package fleet
+
+// Vehicle is an electric scooter identified by its frame-stamped VIN.
+//
+// The platform observes vehicles through application-layer telemetry: periodic
+// heartbeats when idle (60-120 s) and high-frequency beacons during rides
+// (2-5 s). Ephemeral properties (Speed, GNSS, InRide) are retracted when
+// telemetry goes silent beyond a configured TTL; stable associations persist
+// as historical record.
+type Vehicle struct {
+	VIN         string  // Primary key. Frame identity stamped at manufacture.
+	Speed       float64 // Ground speed in km/h, derived from GNSS.
+	Heading     float64 // Course over ground in degrees, 0-360.
+	GNSS        GNSS    // Satellite fix from the scooter's GPS receiver.
+	InRide      bool    // Whether a ride is in progress (platform-inferred from telemetry pattern).
+	Odometer    float64 // Cumulative trip distance in km.
+	AccelMotion bool    // Accelerometer motion-detection flag.
+	AccelTilt   float64 // Tilt angle in degrees (0 = upright, 90 = on its side).
+}
+
+// GNSS holds a satellite fix from the scooter's GPS receiver.
+//
+// This is a wide struct: "last reported GNSS fix" means the entire value
+// including precision metadata, not just coordinates. A zero-value GNSS
+// represents no fix (the receiver has not acquired satellites).
+type GNSS struct {
+	Lat  float64 // WGS 84 latitude.
+	Lng  float64 // WGS 84 longitude.
+	Alt  float64 // Altitude in meters above sea level.
+	HDOP float64 // Horizontal dilution of precision (lower is better).
+	Sats uint8   // Number of satellites used in the fix.
+	Fix  string  // Fix quality: "none", "2d", or "3d".
+}
+
+// Fix quality constants for [GNSS.Fix].
+const (
+	FixNone = "none"
+	Fix2D   = "2d"
+	Fix3D   = "3d"
+)

--- a/samples/micromobility/fleet/vehicle.go
+++ b/samples/micromobility/fleet/vehicle.go
@@ -56,6 +56,15 @@ const (
 // network: the interface through which telemetry reaches the operator's
 // backend.
 //
+// These fields are self-reported by the scooter's application software:
+// the IP is read from the OS network stack, and the modem identifiers are
+// queried via the AT command interface when the firmware supports it.
+// Access values are confirmatory, not authoritative: the network tap's
+// view of the same modem ([radio.Modem]) is the source of truth for
+// network-layer identity. The two observations arrive through independent
+// channels and may disagree temporarily (e.g., after an IP change that the
+// network tap sees before the next telemetry beacon).
+//
 // The connectivity model varies by operator and hardware generation. A
 // scooter with a built-in cellular modem maintains a persistent data session
 // even when idle; a phone-bridged scooter communicates only during rides
@@ -66,11 +75,9 @@ const (
 // at their zero values.
 type Access struct {
 	Type  string     // Connectivity variant: "cellular", "bluetooth", or "station".
-	IP    netip.Addr // Cellular: current data-session IP.
+	IP    netip.Addr // Cellular: current data-session IP from the OS network stack.
 	IMEI  string     // Cellular: modem IMEI, if the firmware queries the AT interface.
-	EID   string     // Cellular: eUICC chip identity (optional).
-	ICCID string     // Cellular: active eSIM profile (optional).
-	IMSI  string     // Cellular: subscriber identity (optional).
+	IMSI  string     // Cellular: subscriber identity, if available via AT+CIMI or equivalent.
 	BLE   string     // Bluetooth: rider's phone BLE device name (Local Name).
 	BSSID string     // Station: WiFi BSSID or operator-assigned dock ID.
 }

--- a/samples/micromobility/fleet/vehicle.go
+++ b/samples/micromobility/fleet/vehicle.go
@@ -73,6 +73,15 @@ const (
 //
 // The Type field selects the variant; fields belonging to other variants are
 // at their zero values.
+//
+// IP is a deliberate simplification. A real cellular session may carry
+// multiple addresses at once: an IPv4 and an IPv6 from a dual-stack PDP
+// context, or several IPs across multiple PDP contexts (e.g. a fleet-side
+// management APN alongside a payload APN). Modeling all of them would
+// require a slice and a way to attribute each address to its PDP context.
+// This sample keeps a single primary IP because the narrative does not
+// exercise multi-context scenarios; a production model would lift this
+// restriction.
 type Access struct {
 	Type  string     // Connectivity variant: "cellular", "bluetooth", or "station".
 	IP    netip.Addr // Cellular: current data-session IP from the OS network stack.

--- a/samples/micromobility/fleet/vehicle.go
+++ b/samples/micromobility/fleet/vehicle.go
@@ -16,14 +16,16 @@ package fleet
 // telemetry goes silent beyond a configured TTL; stable associations persist
 // as historical record.
 type Vehicle struct {
-	VIN         string  // Primary key. Frame identity stamped at manufacture.
-	Speed       float64 // Ground speed in km/h, derived from GNSS.
-	Heading     float64 // Course over ground in degrees, 0-360.
-	GNSS        GNSS    // Satellite fix from the scooter's GPS receiver.
-	InRide      bool    // Whether a ride is in progress (platform-inferred from telemetry pattern).
-	Odometer    float64 // Cumulative trip distance in km.
-	AccelMotion bool    // Accelerometer motion-detection flag.
-	AccelTilt   float64 // Tilt angle in degrees (0 = upright, 90 = on its side).
+	VIN           string  // Primary key. Frame identity stamped at manufacture.
+	ModemIMEI     string  // Foreign key → [radio.Modem]. Which cellular modem is installed.
+	BatterySerial string  // Foreign key → [Battery]. Which battery pack is installed.
+	Speed         float64 // Ground speed in km/h, derived from GNSS.
+	Heading       float64 // Course over ground in degrees, 0-360.
+	GNSS          GNSS    // Satellite fix from the scooter's GPS receiver.
+	InRide        bool    // Whether a ride is in progress (platform-inferred from telemetry pattern).
+	Odometer      float64 // Cumulative trip distance in km.
+	AccelMotion   bool    // Accelerometer motion-detection flag.
+	AccelTilt     float64 // Tilt angle in degrees (0 = upright, 90 = on its side).
 }
 
 // GNSS holds a satellite fix from the scooter's GPS receiver.

--- a/samples/micromobility/go.mod
+++ b/samples/micromobility/go.mod
@@ -1,0 +1,3 @@
+module example/micromobility
+
+go 1.25

--- a/samples/micromobility/go.mod
+++ b/samples/micromobility/go.mod
@@ -1,3 +1,7 @@
 module example/micromobility
 
-go 1.25
+go 1.25.0
+
+require github.com/go-digitaltwin/v2-experiment v0.0.0
+
+replace github.com/go-digitaltwin/v2-experiment => ../..

--- a/samples/micromobility/radio/radio.go
+++ b/samples/micromobility/radio/radio.go
@@ -1,0 +1,45 @@
+// Package radio defines the cellular infrastructure observed through the
+// network tap: modems, eSIM profiles, and cell attachments.
+//
+// The observation platform taps into the cellular network stack to see
+// signaling events (attach, detach, handover), DNS queries, and IP session
+// state. This is a real-time, high-frequency data source anchored on the
+// modem's IMEI. It provides network-layer identity and the raw material for
+// operator and model classification.
+//
+// Modem and [fleet.Vehicle] are separate entities observed through independent
+// channels (network layer vs. application layer). For cellular-connected
+// scooters both are present and correlated; for phone-bridged scooters the
+// Vehicle may exist without a stable Modem anchor.
+package radio
+
+import "net/netip"
+
+// Modem is a cellular modem identified by its 15-digit IMEI.
+//
+// Scooters with built-in cellular connectivity carry two permanent hardware
+// identifiers: an IMEI (the modem) and an EID (the eUICC chip). The active
+// eSIM profile adds an ICCID and IMSI; these change when the operator
+// remotely provisions a new profile (e.g. to switch carriers). The IP
+// address is ephemeral, reassigned on every new data session.
+type Modem struct {
+	IMEI        string      // Primary key. Hardware modem identity, etched at manufacture.
+	EID         string      // eUICC chip identity. Permanent; changes only if hardware is replaced.
+	ICCID       string      // Active eSIM profile identifier. Changes on reprovisioning.
+	IMSI        string      // Subscriber identity used by the network for authentication and routing.
+	IP          netip.Addr  // Current data-session IP address. Retracted when the session drops.
+	ServingCell ServingCell // Current cell attachment as seen by the network tap.
+	Firmware    string      // Modem firmware version.
+}
+
+// ServingCell holds the network tap's observation of a modem's cell attachment.
+//
+// This data is exclusively network-side: the scooter's own software has no
+// access to radio-level information (serving cell, signal quality, neighbor
+// cells). The platform observes it through signaling events on the IMSI.
+type ServingCell struct {
+	PLMN           string // Public Land Mobile Network identifier (MCC-MNC).
+	TrackingArea   uint16 // Tracking area code.
+	CellID         uint32 // E-UTRAN cell identity.
+	SignalStrength int    // Reference signal received power (RSRP) in dBm.
+}


### PR DESCRIPTION
The framework has delta builders and a storage design but no concrete domain to exercise them against. A sample domain model grounds the documentation, gives contributors a working example to study, and will serve as the integration target for the entities service and bronze batcher when those are built.

Shared electric scooters (Lime, Bird, Dot) observed through a cellular network platform are the domain. The choice is deliberate: scooters are tangible, the connectivity model creates natural layering (network observation vs. physical assets vs. competing classifications), and the real-world variance (multiple operators, hardware generations, connectivity modes) exercises every framework pattern without requiring domain expertise to follow.

The bulk of this branch is the README narrative ("A Scooter's Day") that traces one scooter through a full day of events: battery swap, morning commute, IP reassignment, silence and staleness, eSIM reprovisioning, decommission. The story establishes the instrumentation model (vendor instrument, network tap, telemetry feed), the telemetry payload spec, connectivity variance, and the principle that overlapping observations from independent instruments are a feature: agreement reinforces consistency, discrepancy is a signal for higher-order mechanisms.

The Go types follow from the story. Three domain-oriented packages under `samples/micromobility/` model the entities (radio, fleet, classify), and a new `fingerprint/` package at the repo root defines reusable classification types (`Classification`, `Signature`) that any domain model can embed for competing-guess scenarios. The `fingerprint` package is not sample-specific; it belongs to the framework.

The domain model does not yet generate delta builders (`go:generate` directives are not wired up). That depends on teaching the generator to handle embedded structs, where anonymous fields promote their members while named struct fields are replaced atomically. This is tracked separately.