### PR TITLE
Separate external telemetry from digested twin state in the scooters sample

### DIFF
--- a/samples/micromobility/README.md
+++ b/samples/micromobility/README.md
@@ -302,15 +302,49 @@ The battery sub-fields are partially redundant: `battery.energy` divided by
 down from `battery.design_energy` over the pack's life as cycles accumulate.
 Real BMSs expose different subsets of these readings: some surface only a
 percentage, others publish the underlying energies and an instantaneous
-`battery.power`. The digested domain model holds a single normalized state of
-charge derived from whichever measurements the instrument provides; the raw
-fields stay in the analytics tier for downstream battery health analysis.
+`battery.power`. The digested domain model (`fleet.Battery`) holds a single
+normalized state of charge derived from whichever measurements the instrument
+provides; the raw fields stay in the external `telemetry.Battery`, available to
+the analytics tier for downstream battery health analysis.
 
 The `device_id` is the application-layer identity of the scooter. It is
 independent of the IMEI: the IMEI belongs to the modem at the network layer,
 while the `device_id` belongs to the scooter's software at the application
 layer. The platform correlates the two by observing which `device_id` payloads
 flow through which IMEI's IP session.
+
+### External Payload, Digested Twin
+
+The payload above has two representations in the model, at two altitudes:
+
+- **External.** The raw report, captured as it crosses into the platform from
+  the outside, in `telemetry.Report`. It keeps the full envelope (`seq`, `ts`,
+  `trigger`), the redundant battery energies, and the self-reported network
+  identity in `telemetry.Access`, exactly as the source delivered them. Nothing
+  is discarded; the report is retained for battery-health analysis,
+  corroboration against the network tap, and replay.
+- **Digested twin.** The live domain state derived from those reports:
+  `fleet.Vehicle`, `fleet.Battery`, and the network-tap-correlated
+  `radio.Modem`. The digest normalizes and drops. The battery's raw energies
+  collapse to a single state of charge. The envelope falls away, because state
+  carries no record of _why_ it was reported. The self-reported `access` reduces
+  to `fleet.Attachment`: the connectivity mode plus the anchors the telemetry
+  uniquely provides (the phone's BLE name, the dock id). The cellular network
+  identity is _not_ copied onto the vehicle; it belongs to `radio.Modem`,
+  reached through the vehicle's `ModemIMEI`, whose network-tap view is
+  authoritative.
+
+The two layers also key differently. A report is keyed on `device_id`, the
+firmware's self-assigned identity (a VIN or an operator-assigned fleet id). The
+twin is keyed on the resolved VIN. Bridging the two is an identity-resolution
+step performed during digestion, using the vendor instrument.
+
+This sample models the telemetry feed's external layer in full because it is the
+richest source and the one with the widest gap between raw and digested. The
+network tap and the vendor instrument feed the twin through the same
+source-to-digest pattern, but their raw layers are not expanded here: a network
+tap's observation is already close to the modem state it produces, leaving
+little to digest.
 
 ### Triggers
 

--- a/samples/micromobility/external/telemetry/telemetry.go
+++ b/samples/micromobility/external/telemetry/telemetry.go
@@ -1,0 +1,130 @@
+// Package telemetry is the as-delivered representation of the application-layer
+// telemetry a scooter's firmware emits: the raw report payload as it crosses
+// into the platform from the outside, before any digestion.
+//
+// A [Report] mirrors the wire format the feed exports. It is deliberately
+// faithful to the source, not digested: it keeps the full envelope (sequence,
+// timestamp, trigger), the redundant battery energies, and the self-reported
+// network identity in [Access]. Nothing is discarded. The digested twin
+// (fleet.Vehicle, fleet.Battery, and the network-tap-correlated radio.Modem)
+// is derived from these reports; the raw fields are retained here for
+// downstream battery-health analysis, corroboration against the network tap,
+// and replay.
+//
+// Reports are keyed on [Report.DeviceID] — the firmware's self-assigned
+// identity, a VIN or an operator-assigned fleet id — not the resolved twin key.
+// Mapping a DeviceID to a fleet.Vehicle VIN is an identity-resolution step
+// performed during digestion, using the vendor instrument.
+package telemetry
+
+import (
+	"net/netip"
+	"time"
+)
+
+// Report is one telemetry payload as delivered by the feed.
+//
+// The sensor sub-objects are pointers because the firmware omits what it cannot
+// populate: there is no GNSS on a report sent before the receiver has a fix,
+// and a battery-swap report carries only the new pack's reading. A non-nil
+// pointer means the firmware reported that sensor in this payload.
+type Report struct {
+	DeviceID string    `json:"device_id"` // Firmware identity: a VIN or operator-assigned fleet id.
+	Time     time.Time `json:"ts"`        // Timestamp at the scooter's clock (ISO 8601).
+	Seq      uint32    `json:"seq"`       // Monotonic sequence number; gaps reveal lost reports.
+	Trigger  string    `json:"trigger"`   // Why this report was sent. See the Trigger constants.
+
+	GNSS     *GNSS    `json:"gnss,omitempty"`
+	Speed    float64  `json:"speed"`              // Ground speed in km/h (GNSS-derived).
+	Heading  float64  `json:"heading"`            // Course over ground in degrees, 0-360.
+	Odometer *float64 `json:"odometer,omitempty"` // Cumulative trip distance in km; ride reports only.
+	Battery  *Battery `json:"battery,omitempty"`
+	Access   *Access  `json:"access,omitempty"`
+	Accel    *Accel   `json:"accel,omitempty"`
+}
+
+// GNSS is the satellite-fix sub-object. An absent Report.GNSS pointer or a Fix
+// of [FixNone] means the receiver had no positional fix.
+type GNSS struct {
+	Lat  float64 `json:"lat"`
+	Lng  float64 `json:"lng"`
+	Alt  float64 `json:"alt,omitempty"`  // Altitude in meters above sea level.
+	HDOP float64 `json:"hdop,omitempty"` // Horizontal dilution of precision (lower is better).
+	Sats uint8   `json:"sats,omitempty"` // Satellites used in the fix.
+	Fix  string  `json:"fix"`            // Fix quality. See the Fix constants.
+}
+
+// Fix quality values for [GNSS.Fix].
+const (
+	FixNone = "none"
+	Fix2D   = "2d"
+	Fix3D   = "3d"
+)
+
+// Battery is the raw BMS sub-object. It is intentionally wide and redundant:
+// Energy divided by FullEnergy is the state of charge, and FullEnergy trends
+// down from DesignEnergy as cycles accumulate. Real BMSs expose different
+// subsets of these readings. The platform digests whichever measurements arrive
+// into a single normalized state of charge on fleet.Battery, keeping the raw
+// energies here for downstream battery-health analysis.
+type Battery struct {
+	ID           string  `json:"id"`                      // BMS-reported serial of the installed pack.
+	SoC          float64 `json:"soc,omitempty"`           // State of charge, 0.0-1.0, when reported directly.
+	Voltage      float64 `json:"voltage,omitempty"`       // Pack voltage in volts.
+	DesignEnergy uint32  `json:"design_energy,omitempty"` // Factory full-charge energy when new, in mWh.
+	FullEnergy   uint32  `json:"full_energy,omitempty"`   // Latest measured full-charge capacity, in mWh.
+	Energy       uint32  `json:"energy,omitempty"`        // Current stored energy, in mWh.
+	Power        int     `json:"power,omitempty"`         // Instantaneous power in mW (+ charging, - load).
+	Temp         int     `json:"temp,omitempty"`          // Cell temperature in degrees Celsius.
+	Cycles       uint32  `json:"cycles,omitempty"`        // Lifetime charge-cycle count.
+}
+
+// Access is the self-reported point-of-attachment sub-object: the interface
+// through which the firmware believes its telemetry reaches the backend.
+//
+// These values are the firmware's own view: the IP is read from the OS network
+// stack, the modem identifiers via the AT command interface when the firmware
+// supports it. They are confirmatory, not authoritative — the network tap's
+// view of the same modem (radio.Modem) is the source of truth for network-layer
+// identity, and the two may disagree temporarily (e.g. after an IP change the
+// tap sees before the next beacon). The digest keeps only the attachment mode
+// and the application-unique anchors (BLE name, dock id) on fleet.Vehicle; the
+// raw network identity here is retained for corroboration against the network
+// tap.
+//
+// Type selects the variant; fields of other variants are at their zero values.
+type Access struct {
+	Type  string     `json:"type"`            // Connectivity variant. See the Access constants.
+	IP    netip.Addr `json:"ip"`              // Cellular: data-session IP from the OS network stack.
+	IMEI  string     `json:"imei,omitempty"`  // Cellular: modem IMEI via AT, if the firmware queries it.
+	IMSI  string     `json:"imsi,omitempty"`  // Cellular: subscriber identity via AT, if available.
+	BLE   string     `json:"ble,omitempty"`   // Bluetooth: rider's phone BLE device name (Local Name).
+	BSSID string     `json:"bssid,omitempty"` // Station: WiFi BSSID or operator-assigned dock id.
+}
+
+// Access variants for [Access.Type].
+const (
+	AccessCellular  = "cellular"
+	AccessBluetooth = "bluetooth"
+	AccessStation   = "station"
+)
+
+// Accel is the accelerometer sub-object.
+type Accel struct {
+	Motion bool    `json:"motion"`         // Motion-detection flag.
+	Tilt   float64 `json:"tilt,omitempty"` // Tilt angle in degrees (0 = upright, 90 = on its side).
+}
+
+// Trigger values for [Report.Trigger]. A report is either periodic (fired on a
+// timer) or edge-triggered (fired by a state change the firmware detects).
+const (
+	TriggerPeriodic     = "periodic"      // Idle or in-ride heartbeat, on a timer.
+	TriggerMotionStart  = "motion_start"  // Accelerometer went from stationary to moving.
+	TriggerMotionStop   = "motion_stop"   // Accelerometer went from moving to stationary.
+	TriggerImpact       = "impact"        // Accelerometer spike past the impact threshold.
+	TriggerBatterySwap  = "battery_swap"  // BMS reports a different serial after a power cycle.
+	TriggerLowBattery   = "low_battery"   // State of charge dropped below the configured threshold.
+	TriggerAccessUpdate = "access_update" // Point of attachment changed (new IP, phone, or dock).
+	TriggerGNSSFix      = "gnss_fix"      // Receiver acquired a fix after a period with none.
+	TriggerPowerOn      = "power_on"      // Booted after battery insertion or deep-sleep wake.
+)

--- a/samples/micromobility/fleet/battery.go
+++ b/samples/micromobility/fleet/battery.go
@@ -9,6 +9,11 @@ package fleet
 // BMS readings in each scooter's telemetry payload. A battery-swap event
 // manifests as a sudden change in the reported serial number.
 //
+// This is the digested twin state: a single normalized state of charge plus
+// the readings the twin needs. The raw BMS sub-object (the external
+// telemetry.Battery) is wider, carrying the redundant design, full, and
+// instantaneous energies that downstream battery-health analysis consumes.
+//
 // The Vehicle→Battery relationship is maintained on [Vehicle] (BatterySerial),
 // not here. If a reverse link (Battery→Vehicle) is ever needed, it will be
 // added as a field with supporting causality mechanisms to keep both sides

--- a/samples/micromobility/fleet/vehicle.go
+++ b/samples/micromobility/fleet/vehicle.go
@@ -6,9 +6,13 @@
 // whatever network interface is available. The observation platform learns
 // about vehicles from the telemetry payloads they emit, not from operator
 // fleet management systems.
+//
+// The types here are the digested twin state. The raw payloads they are
+// derived from arrive from outside the platform and live in the external
+// telemetry package as telemetry.Report; the digest normalizes those reports
+// into the state the twin needs and drops the envelope and redundant readings
+// the twin does not.
 package fleet
-
-import "net/netip"
 
 // Vehicle is an electric scooter identified by its frame-stamped VIN.
 //
@@ -18,17 +22,17 @@ import "net/netip"
 // telemetry goes silent beyond a configured TTL; stable associations persist
 // as historical record.
 type Vehicle struct {
-	VIN           string  // Primary key. Frame identity stamped at manufacture.
-	ModemIMEI     string  // Foreign key → [radio.Modem]. Which cellular modem is installed.
-	BatterySerial string  // Foreign key → [Battery]. Which battery pack is installed.
-	Speed         float64 // Ground speed in km/h, derived from GNSS.
-	Heading       float64 // Course over ground in degrees, 0-360.
-	GNSS          GNSS    // Satellite fix from the scooter's GPS receiver.
-	InRide        bool    // Whether a ride is in progress (platform-inferred from telemetry pattern).
-	Odometer      float64 // Cumulative trip distance in km.
-	AccelMotion   bool    // Accelerometer motion-detection flag.
-	AccelTilt     float64 // Tilt angle in degrees (0 = upright, 90 = on its side).
-	Access        Access  // Current point of attachment to the wider network.
+	VIN           string     // Primary key. Frame identity stamped at manufacture.
+	ModemIMEI     string     // Foreign key → [radio.Modem]. Which cellular modem is installed.
+	BatterySerial string     // Foreign key → [Battery]. Which battery pack is installed.
+	Speed         float64    // Ground speed in km/h, derived from GNSS.
+	Heading       float64    // Course over ground in degrees, 0-360.
+	GNSS          GNSS       // Satellite fix from the scooter's GPS receiver.
+	InRide        bool       // Whether a ride is in progress (platform-inferred from telemetry pattern).
+	Odometer      float64    // Cumulative trip distance in km.
+	AccelMotion   bool       // Accelerometer motion-detection flag.
+	AccelTilt     float64    // Tilt angle in degrees (0 = upright, 90 = on its side).
+	Attachment    Attachment // Current point of attachment, digested from telemetry.
 }
 
 // GNSS holds a satellite fix from the scooter's GPS receiver.
@@ -52,48 +56,34 @@ const (
 	Fix3D   = "3d"
 )
 
-// Access describes a scooter's current point of attachment to the wider
-// network: the interface through which telemetry reaches the operator's
-// backend.
+// Attachment is the digested point of attachment: how the scooter is currently
+// reaching the backend. It is derived from the telemetry feed's raw access
+// sub-object (telemetry.Access), reduced to twin state.
 //
-// These fields are self-reported by the scooter's application software:
-// the IP is read from the OS network stack, and the modem identifiers are
-// queried via the AT command interface when the firmware supports it.
-// Access values are confirmatory, not authoritative: the network tap's
-// view of the same modem ([radio.Modem]) is the source of truth for
-// network-layer identity. The two observations arrive through independent
-// channels and may disagree temporarily (e.g., after an IP change that the
-// network tap sees before the next telemetry beacon).
+// Only the mode and the application-unique anchors live here. For [AttachCellular],
+// the network identity (IP, IMEI, IMSI) is not duplicated onto the vehicle: it
+// belongs to the modem and is reached through [Vehicle.ModemIMEI] → [radio.Modem],
+// whose network-tap view is authoritative. The telemetry's self-reported copy of
+// that identity stays in the external telemetry layer for corroboration against the tap.
+// [AttachBluetooth] and [AttachStation] carry anchors the network tap never sees
+// (the phone's BLE name, the dock id), so the telemetry feed is their only source.
 //
-// The connectivity model varies by operator and hardware generation. A
-// scooter with a built-in cellular modem maintains a persistent data session
-// even when idle; a phone-bridged scooter communicates only during rides
-// through the rider's phone; a docked scooter uploads buffered telemetry
-// over station WiFi.
+// The connectivity model varies by operator and hardware generation. A scooter
+// with a built-in cellular modem maintains a persistent data session even when
+// idle; a phone-bridged scooter communicates only during rides through the
+// rider's phone; a docked scooter uploads buffered telemetry over station WiFi.
 //
-// The Type field selects the variant; fields belonging to other variants are
-// at their zero values.
-//
-// IP is a deliberate simplification. A real cellular session may carry
-// multiple addresses at once: an IPv4 and an IPv6 from a dual-stack PDP
-// context, or several IPs across multiple PDP contexts (e.g. a fleet-side
-// management APN alongside a payload APN). Modeling all of them would
-// require a slice and a way to attribute each address to its PDP context.
-// This sample keeps a single primary IP because the narrative does not
-// exercise multi-context scenarios; a production model would lift this
-// restriction.
-type Access struct {
-	Type  string     // Connectivity variant: "cellular", "bluetooth", or "station".
-	IP    netip.Addr // Cellular: current data-session IP from the OS network stack.
-	IMEI  string     // Cellular: modem IMEI, if the firmware queries the AT interface.
-	IMSI  string     // Cellular: subscriber identity, if available via AT+CIMI or equivalent.
-	BLE   string     // Bluetooth: rider's phone BLE device name (Local Name).
-	BSSID string     // Station: WiFi BSSID or operator-assigned dock ID.
+// Mode selects the variant; fields belonging to other variants are at their
+// zero values.
+type Attachment struct {
+	Mode   string // Connectivity variant: "cellular", "bluetooth", or "station".
+	BLE    string // Bluetooth: rider's phone BLE device name (Local Name).
+	DockID string // Station: WiFi BSSID or operator-assigned dock ID.
 }
 
-// Access type constants for [Access.Type].
+// Attachment mode constants for [Attachment.Mode].
 const (
-	AccessCellular  = "cellular"
-	AccessBluetooth = "bluetooth"
-	AccessStation   = "station"
+	AttachCellular  = "cellular"
+	AttachBluetooth = "bluetooth"
+	AttachStation   = "station"
 )


### PR DESCRIPTION
The scooters sample (added in #28) drew a careful line between the raw telemetry a scooter emits and the digested state the digital twin holds — but in one place the line blurred. `Vehicle.Access` lifted the telemetry payload's `access` sub-object verbatim, tagged-union shape and all, and its cellular variant carried the IP, IMEI, and IMSI that `radio.Modem` already holds authoritatively from the network tap. The sample digested battery readings (a normalized state of charge, raw energies pushed elsewhere) yet echoed the access payload straight into the twin, so the telemetry/twin boundary the rest of the model maintains was applied inconsistently.

This change gives the raw payload a home of its own and reduces the twin to genuine digested state. A new `telemetry.Report` (under `external/`) is the as-delivered representation of the payload: the full envelope, the redundant battery energies, and the self-reported network identity, exactly as the source feed hands them over. `Vehicle.Access` becomes `Vehicle.Attachment`, the digested form — the connectivity mode plus the anchors telemetry uniquely provides (the phone's BLE name, the dock id). The cellular network identity is no longer copied onto the vehicle; it stays on `radio.Modem`, reached through `ModemIMEI`, while the firmware's self-reported copy lives in the external layer for corroboration against the network tap. The README gains an "External Payload, Digested Twin" section naming both altitudes and the digest between them.

The directory is named `external/` rather than `bronze/` deliberately: the framing is provenance (data arriving from outside the platform), not our own medallion vocabulary, and the name generalizes to the network tap and vendor instrument when those raw layers are expanded later.

Scope is intentionally narrow. Only the telemetry feed's external layer is modeled; the network tap and vendor instrument feed the twin through the same source-to-digest pattern but are not expanded here, because a tap's observation already sits close to the modem state it produces and leaves little to digest. No digest function is included — the two layers are types and prose only; the mapping between them belongs to a future ingestion pipeline. The `device_id` → resolved-VIN identity resolution is described but not modeled (there is no `FleetID` type yet); it is the first thing that pipeline will need.

This is a documentation-and-types refinement of the sample, with no production code paths affected.
